### PR TITLE
JCN-query-builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+-  `addDbName` method form `Model` not need.
+
 ## [1.1.0] - 2019-07-17
 ### Changed
 - moved `utils/` to `/lib`

--- a/lib/query-builder-joins.js
+++ b/lib/query-builder-joins.js
@@ -278,7 +278,7 @@ class QueryBuilderJoins {
 	static _getJoinTable(joinKey) {
 		const modelJoin = this.joins[joinKey];
 		const table = modelJoin.table || joinKey;
-		return `${this.model.addDbName(table)} as ${modelJoin.alias}`;
+		return `${table} as ${modelJoin.alias}`;
 	}
 
 	/**

--- a/lib/query-builder.js
+++ b/lib/query-builder.js
@@ -46,7 +46,7 @@ class QueryBuilder {
 	 */
 	_init() {
 
-		this.knexStatement = this.knex({ t: this.model.addDbName(this.table) });
+		this.knexStatement = this.knex({ t: this.table });
 		this.knexStatement.raw = this.knex.raw;
 	}
 
@@ -55,7 +55,7 @@ class QueryBuilder {
 	 */
 	_initWithoutAlias() {
 
-		this.knexStatement = this.knex(this.model.addDbName(this.table));
+		this.knexStatement = this.knex(this.table);
 		this.knexStatement.raw = this.knex.raw;
 	}
 
@@ -304,11 +304,11 @@ class QueryBuilder {
 	 * Get Fields from Table in database
 	 */
 	async _getFields() {
-		const table = this.model.addDbName(this.table);
+
 		let rows;
 
 		try {
-			[rows] = await this.knex.raw(`SHOW COLUMNS FROM ${table};`);
+			[rows] = await this.knex.raw(`SHOW COLUMNS FROM ${this.table};`);
 		} catch(error) {
 			throw new QueryBuilderError('Can\'t get Table information from Database', QueryBuilderError.codes.INVALID_TABLE);
 		}

--- a/tests/query-builder-fields-test.js
+++ b/tests/query-builder-fields-test.js
@@ -45,9 +45,6 @@ const makeModel = ({
 			return joins;
 		}
 
-		addDbName(t) {
-			return t;
-		}
 	}
 
 	return new FakeModel();

--- a/tests/query-builder-filters-test.js
+++ b/tests/query-builder-filters-test.js
@@ -45,9 +45,6 @@ const makeModel = ({
 			return joins;
 		}
 
-		addDbName(t) {
-			return t;
-		}
 	}
 
 	return new FakeModel();

--- a/tests/query-builder-group-test.js
+++ b/tests/query-builder-group-test.js
@@ -45,9 +45,6 @@ const makeModel = ({
 			return joins;
 		}
 
-		addDbName(t) {
-			return t;
-		}
 	}
 
 	return new FakeModel();

--- a/tests/query-builder-joins-test.js
+++ b/tests/query-builder-joins-test.js
@@ -45,10 +45,6 @@ const makeModel = ({
 		static get joins() {
 			return joins;
 		}
-
-		addDbName(t) {
-			return t;
-		}
 	}
 
 	return new FakeModel();

--- a/tests/query-builder-order-test.js
+++ b/tests/query-builder-order-test.js
@@ -44,10 +44,6 @@ const makeModel = ({
 		static get joins() {
 			return joins;
 		}
-
-		addDbName(t) {
-			return t;
-		}
 	}
 
 	return new FakeModel();

--- a/tests/query-builder-test.js
+++ b/tests/query-builder-test.js
@@ -95,10 +95,6 @@ const makeModel = ({
 		static get joins() {
 			return joins;
 		}
-
-		addDbName(t) {
-			return t;
-		}
 	}
 
 	return new FakeModel();
@@ -135,9 +131,6 @@ function queryBuilderFactory({
 			return joins;
 		}
 
-		addDbName(t) {
-			return t;
-		}
 	}
 
 	const knex = knexSpy || makeKnexFunction();


### PR DESCRIPTION
# **[QUICK] QUERY-BUILDER-FIX **

## **Descripción del requerimiento**

- Eliminar el uso del metodo `addDbName` del `Model` para el armado de los queries

## **Descripción de la solución **

- Se elimino el uso del metodo `addDbName`