### PR TITLE
JCN 125 joins automaticos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+## Changed
+- `joins` are added automatic
+
 ## [1.2.0] - 2019-07-25
 ### Changed
 -  `addDbName` method form `Model` not need.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ See [More](https://github.com/janis-commerce/query-builder/blob/master/docs/Spec
 
 ### Joins
 
-To join tables, use `joins` as *key*.
+Joins are Automatic.
 
 See [More](https://github.com/janis-commerce/query-builder/blob/master/docs/Joins.md)
 
@@ -149,7 +149,7 @@ await queryBuilder.update(values, filters);
 
 // Remove any Items
 // joins, object with table joins define if it's possible
-await queryBuilder.remove(filters, joins);
+await queryBuilder.remove(filters);
 
 // Get Items
 // Get All

--- a/docs/Groups.md
+++ b/docs/Groups.md
@@ -6,9 +6,7 @@ Use `group` *key* to group by fields. It's SQL equivalent to `GROUP BY`.
 
     ```javascript
     const parametres = {
-        filters: { 
-            group: 'some'
-        }
+        group: 'some'
     }
 
     const query = new QueryBuilder(knex,someModel);
@@ -25,9 +23,7 @@ Use `group` *key* to group by fields. It's SQL equivalent to `GROUP BY`.
 
     ```javascript
     const parametres = {
-        filters: { 
-            group: ['some', 'other']
-        }
+        group: ['some', 'other']
     }
 
     const query = new QueryBuilder(knex,someModel);

--- a/docs/Joins.md
+++ b/docs/Joins.md
@@ -2,23 +2,6 @@
 
 > First, Fields and Join config must be define in **Model** structure.
 
-If you want to join a table, use a `joins` as *key* and `Array` of `String` with the table names as *value*.
-
-```javascript
-parametres = {
-    joins : ['tableB', 'tableC']
-}
-
-const query = new QueryBuilder(knex,someModel);
-const results = await query.get({ joins: ['tableB'] });
-```
-
-The query is :
-
-```sql
-select * from `table` as `t` left join `table_b` as `tb` on `t`.`some` = `tb`.`any`;
-```
-
 ## Model
 
 In the model must be an structured like this:
@@ -40,11 +23,31 @@ In the model must be an structured like this:
             tableB: {
                 table: 'tableB',
                 alias: 'tb',
-                on: ['foo', 'bar']
+                on: ['bar', 'foo']
             }
         };
     };
 ```
+
+## Usage
+
+The Joins are **Automatic**.
+
+```javascript
+parametres = {
+    fields : ['bar']
+}
+
+const query = new QueryBuilder(knex,someModel);
+const results = await query.get(parametres);
+```
+
+The query is :
+
+```sql
+select `tb.bar` from `table` as `t` left join `table_b` as `tb` on `t`.`foo` = `tb`.`bar`;
+```
+
 - - -
 
 

--- a/lib/query-builder-fields.js
+++ b/lib/query-builder-fields.js
@@ -28,7 +28,7 @@ class QueryBuilderSelect {
 
 	/**
 	 * Search in the fields parameters and return fields that have to join on a table
-	 * @param {object} params Parametres
+	 * @param {object} parameters parameters
 	 * @param {object} modelFields Model fields
 	 * @returns {array}
 	 */
@@ -41,16 +41,16 @@ class QueryBuilderSelect {
 
 	/**
 	 * Search in the parameters for special functions and return fields that have to join on a table
-	 * @param {object} params Parametres
+	 * @param {object} parameters parameters
 	 * @param {object} modelFields Model fields
 	 * @returns {array}
 	 */
-	static getJoinsSpecialFunction(params, modelFields) {
+	static getJoinsSpecialFunction(parameters, modelFields) {
 		const specialFunctions = Object.keys(this.selectFunctions)
-			.filter(specialFunction => params[specialFunction]);
+			.filter(specialFunction => parameters[specialFunction]);
 
 		const fields = specialFunctions.map(specialFunction => {
-			const value = params[specialFunction];
+			const value = parameters[specialFunction];
 			if(typeof value === 'string')
 				return value;
 			if(typeof value === 'object' && !Array.isArray(value))
@@ -63,12 +63,12 @@ class QueryBuilderSelect {
 	}
 
 	/**
-	 * Build Select. Call Knex Select with fields in params
+	 * Build Select. Call Knex Select with fields in parameters
 	 * @param {object} knex must have key 'knexStatement' with knex function
 	 * @param {instance} model
-	 * @param {object} params
+	 * @param {object} parameters
 	 */
-	static buildSelect(knex, model, params) {
+	static buildSelect(knex, model, parameters) {
 
 		if(!knex)
 			throw new QueryBuilderError('Invalid Knex', QueryBuilderError.codes.INVALID_KNEX);
@@ -79,10 +79,10 @@ class QueryBuilderSelect {
 
 		this.initModel(model);
 
-		this.params = params;
+		this.parameters = parameters;
 
 		// eslint-disable-next-line prefer-destructuring
-		const fields = params.fields;
+		const fields = parameters.fields;
 
 		let fieldsForSelect;
 		let flagFieldsForSelect = false;
@@ -90,7 +90,7 @@ class QueryBuilderSelect {
 		if(typeof fields === 'undefined') {
 			fieldsForSelect = 't.*';
 
-			if(!this.params.noFlags)
+			if(!this.parameters.noFlags)
 				flagFieldsForSelect = this._getFlagFieldsForSelect(this._getFlagFields());
 
 		} else if(fields === false)
@@ -351,10 +351,10 @@ class QueryBuilderSelect {
 
 		for(const [selectFunction, selectMethod] of Object.entries(this.selectFunctions)) {
 
-			if(!this.params[selectFunction])
+			if(!this.parameters[selectFunction])
 				continue;
 
-			const data = this.params[selectFunction];
+			const data = this.parameters[selectFunction];
 
 			if(Array.isArray(data))
 				throw new QueryBuilderError(`Param '${selectFunction}' can't be an array`, QueryBuilderError.codes.INVALID_SELECT_FUNCTION);

--- a/lib/query-builder-fields.js
+++ b/lib/query-builder-fields.js
@@ -27,6 +27,42 @@ class QueryBuilderSelect {
 	}
 
 	/**
+	 * Search in the fields parameters and return fields that have to join on a table
+	 * @param {object} params Parametres
+	 * @param {object} modelFields Model fields
+	 * @returns {array}
+	 */
+	static getJoinsFields({ fields }, modelFields) {
+		if(!fields || !Array.isArray(fields))
+			return [];
+
+		return fields.filter(field => (modelFields[field] && modelFields[field].table));
+	}
+
+	/**
+	 * Search in the parameters for special functions and return fields that have to join on a table
+	 * @param {object} params Parametres
+	 * @param {object} modelFields Model fields
+	 * @returns {array}
+	 */
+	static getJoinsSpecialFunction(params, modelFields) {
+		const specialFunctions = Object.keys(this.selectFunctions)
+			.filter(specialFunction => params[specialFunction]);
+
+		const fields = specialFunctions.map(specialFunction => {
+			const value = params[specialFunction];
+			if(typeof value === 'string')
+				return value;
+			if(typeof value === 'object' && !Array.isArray(value))
+				return value.field;
+			return undefined;
+		});
+
+		return fields.filter(field => (modelFields[field] && modelFields[field].table));
+
+	}
+
+	/**
 	 * Build Select. Call Knex Select with fields in params
 	 * @param {object} knex must have key 'knexStatement' with knex function
 	 * @param {instance} model

--- a/lib/query-builder-filters.js
+++ b/lib/query-builder-filters.js
@@ -34,6 +34,27 @@ class QueryBuilderFilters {
 	}
 
 	/**
+	 * Search in the filters parameters and return fields that have to join on a table
+	 * @param {object} params Parametres
+	 * @param {object} modelFields Model fields
+	 * @returns {array}
+	 */
+	static getJoinsFields({ filters }, modelFields) {
+		if(!filters)
+			return [];
+
+		let fields = [];
+
+		const arrayFilters = Array.isArray(filters) ? [...filters] : [filters];
+
+		arrayFilters.forEach(filter => {
+			fields = [...fields, ...Object.keys(filter)];
+		});
+
+		return fields.filter(field => (modelFields[field] && modelFields[field].table));
+	}
+
+	/**
 	 * Builds filters. Add AND or OR filters.
 	 */
 	static buildFilters(knex, model, params) {

--- a/lib/query-builder-filters.js
+++ b/lib/query-builder-filters.js
@@ -35,7 +35,7 @@ class QueryBuilderFilters {
 
 	/**
 	 * Search in the filters parameters and return fields that have to join on a table
-	 * @param {object} params Parametres
+	 * @param {object} parameters parameters
 	 * @param {object} modelFields Model fields
 	 * @returns {array}
 	 */
@@ -57,7 +57,7 @@ class QueryBuilderFilters {
 	/**
 	 * Builds filters. Add AND or OR filters.
 	 */
-	static buildFilters(knex, model, params) {
+	static buildFilters(knex, model, parameters) {
 		if(!knex)
 			throw new QueryBuilderError('Invalid Knex', QueryBuilderError.codes.INVALID_KNEX);
 
@@ -70,7 +70,7 @@ class QueryBuilderFilters {
 		QueryBuilderFields.initModel(model);
 
 		// eslint-disable-next-line prefer-destructuring
-		const filters = params.filters;
+		const filters = parameters.filters;
 
 		if(!filters)
 			return;

--- a/lib/query-builder-group.js
+++ b/lib/query-builder-group.js
@@ -19,6 +19,20 @@ class QueryBuilderGroup {
 	}
 
 	/**
+	 * Search in the group parameters and return fields that have to join on a table
+	 * @param {object} params Parametres
+	 * @param {object} modelFields Model fields
+	 * @returns {array}
+	 */
+	static getJoinsFields({ group }, modelFields) {
+		if(!group || (typeof group === 'object' && !Array.isArray(group)))
+			return [];
+
+		const fields = Array.isArray(group) ? [...group] : [group];
+		return fields.filter(field => (modelFields[field] && modelFields[field].table));
+	}
+
+	/**
 	 * Builds group by function.
 	 * @param {object} knex must have key 'knexStatement' with knex function
 	 * @param {instance} model

--- a/lib/query-builder-group.js
+++ b/lib/query-builder-group.js
@@ -20,7 +20,7 @@ class QueryBuilderGroup {
 
 	/**
 	 * Search in the group parameters and return fields that have to join on a table
-	 * @param {object} params Parametres
+	 * @param {object} parameters parameters
 	 * @param {object} modelFields Model fields
 	 * @returns {array}
 	 */
@@ -36,9 +36,9 @@ class QueryBuilderGroup {
 	 * Builds group by function.
 	 * @param {object} knex must have key 'knexStatement' with knex function
 	 * @param {instance} model
-	 * @param {object} params
+	 * @param {object} parameters
 	 */
-	static buildGroup(knex, model, params) {
+	static buildGroup(knex, model, parameters) {
 
 		if(!knex)
 			throw new QueryBuilderError('Invalid Knex', QueryBuilderError.codes.INVALID_KNEX);
@@ -53,7 +53,7 @@ class QueryBuilderGroup {
 		QueryBuilderFields.initModel(model);
 
 		// eslint-disable-next-line prefer-destructuring
-		let group = params.group;
+		let group = parameters.group;
 
 		if(typeof group === 'undefined' || group === false)
 			return;

--- a/lib/query-builder-joins.js
+++ b/lib/query-builder-joins.js
@@ -41,9 +41,9 @@ class QueryBuilderJoins {
 	 * Build Joins.
 	 * @param {object} knex must have key 'knexStatement' with knex function
 	 * @param {instance} model
-	 * @param {object} params
+	 * @param {object} parameters
 	 */
-	static buildJoins(knex, model, params) {
+	static buildJoins(knex, model, parameters) {
 
 		if(!knex)
 			throw new QueryBuilderError('Invalid Knex', QueryBuilderError.codes.INVALID_KNEX);
@@ -57,7 +57,7 @@ class QueryBuilderJoins {
 		// Need to Init Builder Fields if it's not
 		QueryBuilderFields.initModel(model);
 
-		const { joins } = params;
+		const { joins } = parameters;
 
 		if(!joins)
 			return;

--- a/lib/query-builder-order.js
+++ b/lib/query-builder-order.js
@@ -7,7 +7,7 @@ class QueryBuilderOrder {
 
 	/**
 	 * Search in the order parameters and return fields that have to join on a table
-	 * @param {object} params Parametres
+	 * @param {object} parameters parameters
 	 * @param {object} modelFields Model fields
 	 * @returns {array}
 	 */
@@ -20,11 +20,11 @@ class QueryBuilderOrder {
 	}
 
 	/**
-	 * Build Order By. Call Knex orderBy with order in params
+	 * Build Order By. Call Knex orderBy with order in parameters
      * @param {object} knex must have key 'knexStatement' with knex function
-	 * @param {object} params
+	 * @param {object} parameters
 	 */
-	static buildOrder(knex, model, params) {
+	static buildOrder(knex, model, parameters) {
 		if(!knex)
 			throw new QueryBuilderError('Invalid Knex', QueryBuilderError.codes.INVALID_KNEX);
 
@@ -38,7 +38,7 @@ class QueryBuilderOrder {
 		QueryBuilderFields.initModel(model);
 
 		// eslint-disable-next-line prefer-destructuring
-		let order = params.order;
+		let order = parameters.order;
 		// If not Order to Build
 		if(!order)
 			return;

--- a/lib/query-builder-order.js
+++ b/lib/query-builder-order.js
@@ -6,6 +6,20 @@ const QueryBuilderFields = require('./query-builder-fields');
 class QueryBuilderOrder {
 
 	/**
+	 * Search in the order parameters and return fields that have to join on a table
+	 * @param {object} params Parametres
+	 * @param {object} modelFields Model fields
+	 * @returns {array}
+	 */
+	static getJoinsFields({ order }, modelFields) {
+		if(!order || (typeof order === 'object' && Array.isArray(order)))
+			return [];
+
+		const fields = typeof order === 'object' ? Object.keys(order) : [order];
+		return fields.filter(field => (modelFields[field] && modelFields[field].table));
+	}
+
+	/**
 	 * Build Order By. Call Knex orderBy with order in params
      * @param {object} knex must have key 'knexStatement' with knex function
 	 * @param {object} params

--- a/lib/query-builder-pagination.js
+++ b/lib/query-builder-pagination.js
@@ -5,19 +5,19 @@ const QueryBuilderError = require('./query-builder-error');
 class QueryBuilderPagination {
 
 	/**
-	 * Build Limit and Offset. Call Knex limit and offset methods with params
+	 * Build Limit and Offset. Call Knex limit and offset methods with parameters
 	 * @param {object} knex must have key 'knexStatement' with knex function
-	 * @param {object} params
+	 * @param {object} parameters
 	 */
-	static buildLimit(knex, params) {
+	static buildLimit(knex, parameters) {
 
 		if(!knex)
 			throw new QueryBuilderError('Invalid Knex', QueryBuilderError.codes.INVALID_KNEX);
 
 		// eslint-disable-next-line prefer-destructuring
-		let limit = params.limit;
+		let limit = parameters.limit;
 		// eslint-disable-next-line prefer-destructuring
-		let page = params.page;
+		let page = parameters.page;
 
 		if(limit) {
 
@@ -45,7 +45,7 @@ class QueryBuilderPagination {
 		} else {
 
 			// eslint-disable-next-line prefer-destructuring
-			let offset = params.offset;
+			let offset = parameters.offset;
 
 			if(!offset)
 				return;

--- a/lib/query-builder.js
+++ b/lib/query-builder.js
@@ -23,7 +23,7 @@ class QueryBuilder {
 	 * Query Builder Constructor
 	 * @param {function} knex Knex instance Initializated
 	 * @param {class} model Instance of Model
-	 * @param {object} params Parametres
+	 * @param {object} params parameters
 	 */
 	constructor(knex, model) {
 
@@ -70,12 +70,12 @@ class QueryBuilder {
 
 	/**
 	 * Search objets in the Database.
-	 * @param {objects} parametres Object with Parametres and filters
+	 * @param {objects} parameters Object with parameters and filters
 	 * @return {Promise<Array>} Array of Objects in Database
 	 */
-	async get(parametres = {}) {
+	async get(parameters = {}) {
 
-		this.params = this.prepareParams(parametres);
+		this.params = this.prepareParams(parameters);
 
 		this._init();
 
@@ -246,7 +246,7 @@ class QueryBuilder {
 		if(!values || typeof values !== 'object')
 			throw new QueryBuilderError('No values to Update', QueryBuilderError.codes.NO_VALUES);
 
-		this.params = this.prepareParams({	filters });
+		this.params = this.prepareParams({ filters });
 
 		this._init();
 
@@ -330,34 +330,20 @@ class QueryBuilder {
 	 */
 	prepareParams(params) {
 
-		let fields = [];
 		// to ignore previous joins
 		delete params.joins;
 		// If no params.
 		if(!Object.keys(params).length)
 			return params;
 
-		// Search in the params for fields which uses other tables
-		Object.keys(params).forEach(param => {
-			if(Array.isArray(params[param])) {
-				if(param === 'filters') {
-					params[param].forEach(filter => {
-						fields = [...fields, ...this.getTableFieldsFromObject(filter)];
-					});
-				} else
-					fields = [...fields, ...this.getTableFieldsFromArray(params[param])];
-
-			} else if(typeof params[param] === 'string')
-				this.getTableFieldsFromString(fields, params[param]);
-
-			else if(typeof params[param] === 'object') {
-				if(['count', 'min', 'max', 'sum', 'avg'].includes(param))
-					this.getTableFieldsFromString(fields, params[param].field);
-				else
-					fields = [...fields, ...this.getTableFieldsFromObject(params[param])];
-			}
-
-		});
+		// Filter the params which have a join option
+		const fields = [
+			...QueryBuilderSelect.getJoinsFields(params, this.fields),
+			...QueryBuilderSelect.getJoinsSpecialFunction(params, this.fields),
+			...QueryBuilderFilters.getJoinsFields(params, this.fields),
+			...QueryBuilderOrder.getJoinsFields(params, this.fields),
+			...QueryBuilderGroup.getJoinsFields(params, this.fields)
+		];
 
 		// Get Unique Tables
 		params.joins = [...new Set(fields.map(field => this.fields[field].table))];
@@ -367,19 +353,6 @@ class QueryBuilder {
 			delete params.joins;
 
 		return params;
-	}
-
-	getTableFieldsFromString(fields, field) {
-		if(this.fields[field] && this.fields[field].table)
-			fields.push(field);
-	}
-
-	getTableFieldsFromArray(fields) {
-		return fields.filter(field => (this.fields[field] && this.fields[field].table));
-	}
-
-	getTableFieldsFromObject(fields) {
-		return Object.keys(fields).filter(field => (this.fields[field] && this.fields[field].table));
 	}
 
 }

--- a/lib/query-builder.js
+++ b/lib/query-builder.js
@@ -23,7 +23,7 @@ class QueryBuilder {
 	 * Query Builder Constructor
 	 * @param {function} knex Knex instance Initializated
 	 * @param {class} model Instance of Model
-	 * @param {object} params parameters
+	 * @param {object} parameters parameters
 	 */
 	constructor(knex, model) {
 
@@ -75,23 +75,23 @@ class QueryBuilder {
 	 */
 	async get(parameters = {}) {
 
-		this.params = this.prepareParams(parameters);
+		this.parameters = this.prepareParams(parameters);
 
 		this._init();
 
-		QueryBuilderSelect.buildSelect(this.knexStatement, this.model, this.params);
+		QueryBuilderSelect.buildSelect(this.knexStatement, this.model, this.parameters);
 
 		if(this._modelHasFieldsStructure()) {
-			QueryBuilderJoins.buildJoins(this.knexStatement, this.model, this.params);
-			QueryBuilderFilters.buildFilters(this.knexStatement, this.model, this.params);
-			QueryBuilderOrder.buildOrder(this.knexStatement, this.model, this.params);
-			QueryBuilderGroup.buildGroup(this.knexStatement, this.model, this.params);
+			QueryBuilderJoins.buildJoins(this.knexStatement, this.model, this.parameters);
+			QueryBuilderFilters.buildFilters(this.knexStatement, this.model, this.parameters);
+			QueryBuilderOrder.buildOrder(this.knexStatement, this.model, this.parameters);
+			QueryBuilderGroup.buildGroup(this.knexStatement, this.model, this.parameters);
 		} else
 			logger.warn('QueryBuilder - No fields structure');
 
-		QueryBuilderPagination.buildLimit(this.knexStatement, this.params);
+		QueryBuilderPagination.buildLimit(this.knexStatement, this.parameters);
 
-		if(this.params.debug)
+		if(this.parameters.debug)
 			logger.info('statement', this.knexStatement.toString());
 
 		return this.knexStatement;
@@ -246,13 +246,13 @@ class QueryBuilder {
 		if(!values || typeof values !== 'object')
 			throw new QueryBuilderError('No values to Update', QueryBuilderError.codes.NO_VALUES);
 
-		this.params = this.prepareParams({ filters });
+		this.parameters = this.prepareParams({ filters });
 
 		this._init();
 
 		values = await this._formatUpdateValues(values);
 		try {
-			QueryBuilderFilters.buildFilters(this.knexStatement, this.model, this.params);
+			QueryBuilderFilters.buildFilters(this.knexStatement, this.model, this.parameters);
 			return this.knexStatement.update(values);
 
 		} catch(error) {
@@ -272,14 +272,14 @@ class QueryBuilder {
 
 		this._initWithoutAlias();
 
-		this.params = this.prepareParams({ filters });
+		this.parameters = this.prepareParams({ filters });
 
 		try {
 
 			// Builds the Filters (Where)
-			QueryBuilderFilters.buildFilters(this.knexStatement, this.model, this.params);
+			QueryBuilderFilters.buildFilters(this.knexStatement, this.model, this.parameters);
 			// Builds the Joins
-			QueryBuilderJoins.buildJoins(this.knexStatement, this.model, this.params);
+			QueryBuilderJoins.buildJoins(this.knexStatement, this.model, this.parameters);
 			// Necesary to use Knex, otherwise fails.
 			const deleteQuereyRaw = this._changeQueryTableAlias(this.knexStatement.del().toString());
 
@@ -324,35 +324,35 @@ class QueryBuilder {
 	}
 
 	/**
-	 * Prepare Params to automatic add Joins (if required)
-	 * @param {object} params
+	 * Prepare parameters to automatic add Joins (if required)
+	 * @param {object} parameters
 	 * @returns {object}
 	 */
-	prepareParams(params) {
+	prepareParams(parameters) {
 
 		// to ignore previous joins
-		delete params.joins;
-		// If no params.
-		if(!Object.keys(params).length)
-			return params;
+		delete parameters.joins;
+		// If no parameters.
+		if(!Object.keys(parameters).length)
+			return parameters;
 
-		// Filter the params which have a join option
+		// Filter the parameters which have a join option
 		const fields = [
-			...QueryBuilderSelect.getJoinsFields(params, this.fields),
-			...QueryBuilderSelect.getJoinsSpecialFunction(params, this.fields),
-			...QueryBuilderFilters.getJoinsFields(params, this.fields),
-			...QueryBuilderOrder.getJoinsFields(params, this.fields),
-			...QueryBuilderGroup.getJoinsFields(params, this.fields)
+			...QueryBuilderSelect.getJoinsFields(parameters, this.fields),
+			...QueryBuilderSelect.getJoinsSpecialFunction(parameters, this.fields),
+			...QueryBuilderFilters.getJoinsFields(parameters, this.fields),
+			...QueryBuilderOrder.getJoinsFields(parameters, this.fields),
+			...QueryBuilderGroup.getJoinsFields(parameters, this.fields)
 		];
 
 		// Get Unique Tables
-		params.joins = [...new Set(fields.map(field => this.fields[field].table))];
+		parameters.joins = [...new Set(fields.map(field => this.fields[field].table))];
 
 		// Delete Joins if it's empty
-		if(!params.joins.length)
-			delete params.joins;
+		if(!parameters.joins.length)
+			delete parameters.joins;
 
-		return params;
+		return parameters;
 	}
 
 }

--- a/lib/query-builder.js
+++ b/lib/query-builder.js
@@ -75,7 +75,7 @@ class QueryBuilder {
 	 */
 	async get(parametres = {}) {
 
-		this.params = parametres;
+		this.params = this.prepareParams(parametres);
 
 		this._init();
 
@@ -246,9 +246,7 @@ class QueryBuilder {
 		if(!values || typeof values !== 'object')
 			throw new QueryBuilderError('No values to Update', QueryBuilderError.codes.NO_VALUES);
 
-		this.params = {
-			filters
-		};
+		this.params = this.prepareParams({	filters });
 
 		this._init();
 
@@ -268,17 +266,13 @@ class QueryBuilder {
 	/**
 	 * Delete rows from Database.
 	 * @param {object} filters Object with filters. (Where)
-	 * @param {object} joins Object with Joins.
 	 * @returns {Promise<Array>} Array of Objects, index 0: Results-Headers object
 	 */
-	async remove(filters, joins) {
+	async remove(filters) {
 
 		this._initWithoutAlias();
 
-		this.params = {
-			filters,
-			joins
-		};
+		this.params = this.prepareParams({ filters });
 
 		try {
 
@@ -329,15 +323,21 @@ class QueryBuilder {
 		return fields;
 	}
 
+	/**
+	 * Prepare Params to automatic add Joins (if required)
+	 * @param {object} params
+	 * @returns {object}
+	 */
 	prepareParams(params) {
 
 		let fields = [];
-
+		// to ignore previous joins
 		delete params.joins;
-
-		if(!params)
+		// If no params.
+		if(!Object.keys(params).length)
 			return params;
 
+		// Search in the params for fields which uses other tables
 		Object.keys(params).forEach(param => {
 			if(Array.isArray(params[param])) {
 				if(param === 'filters') {

--- a/lib/query-builder.js
+++ b/lib/query-builder.js
@@ -331,30 +331,55 @@ class QueryBuilder {
 
 	prepareParams(params) {
 
-		// if(!params || !params.fields) -> params.joins = Object.keys(model.joins);
-		// else -> SACAR de los diferentes keys los fields si tienen o no tabla -> agregar tabla
-		if(!params || !params.fields)
-			params.joins = Object.keys(this.model.constructor.joins) || [];
-		else {
-			params.joins = params.fields
-				.filter(field => (this.fields[field] && this.fields[field].table))
-				.map(field => this.fields[field].table);
-		}
+		let fields = [];
 
-		if(params.order) {
-			if(typeof params.order === 'string' && this.fields[params.order].table)
-				params.joins.push(this.fields[params.order].table);
-			else if(typeof params.order === 'object') {
-				Object.keys(params.order)
-					.filter(field => (this.fields[field] && this.fields[field].table))
-					.forEach(field => params.joins.push(this.fields[field].table));
+		delete params.joins;
+
+		if(!params)
+			return params;
+
+		Object.keys(params).forEach(param => {
+			if(Array.isArray(params[param])) {
+				if(param === 'filters') {
+					params[param].forEach(filter => {
+						fields = [...fields, ...this.getTableFieldsFromObject(filter)];
+					});
+				} else
+					fields = [...fields, ...this.getTableFieldsFromArray(params[param])];
+
+			} else if(typeof params[param] === 'string')
+				this.getTableFieldsFromString(fields, params[param]);
+
+			else if(typeof params[param] === 'object') {
+				if(['count', 'min', 'max', 'sum', 'avg'].includes(param))
+					this.getTableFieldsFromString(fields, params[param].field);
+				else
+					fields = [...fields, ...this.getTableFieldsFromObject(params[param])];
 			}
-		}
 
+		});
+
+		// Get Unique Tables
+		params.joins = [...new Set(fields.map(field => this.fields[field].table))];
+
+		// Delete Joins if it's empty
 		if(!params.joins.length)
 			delete params.joins;
 
 		return params;
+	}
+
+	getTableFieldsFromString(fields, field) {
+		if(this.fields[field] && this.fields[field].table)
+			fields.push(field);
+	}
+
+	getTableFieldsFromArray(fields) {
+		return fields.filter(field => (this.fields[field] && this.fields[field].table));
+	}
+
+	getTableFieldsFromObject(fields) {
+		return Object.keys(fields).filter(field => (this.fields[field] && this.fields[field].table));
 	}
 
 }

--- a/lib/query-builder.js
+++ b/lib/query-builder.js
@@ -329,6 +329,34 @@ class QueryBuilder {
 		return fields;
 	}
 
+	prepareParams(params) {
+
+		// if(!params || !params.fields) -> params.joins = Object.keys(model.joins);
+		// else -> SACAR de los diferentes keys los fields si tienen o no tabla -> agregar tabla
+		if(!params || !params.fields)
+			params.joins = Object.keys(this.model.constructor.joins) || [];
+		else {
+			params.joins = params.fields
+				.filter(field => (this.fields[field] && this.fields[field].table))
+				.map(field => this.fields[field].table);
+		}
+
+		if(params.order) {
+			if(typeof params.order === 'string' && this.fields[params.order].table)
+				params.joins.push(this.fields[params.order].table);
+			else if(typeof params.order === 'object') {
+				Object.keys(params.order)
+					.filter(field => (this.fields[field] && this.fields[field].table))
+					.forEach(field => params.joins.push(this.fields[field].table));
+			}
+		}
+
+		if(!params.joins.length)
+			delete params.joins;
+
+		return params;
+	}
+
 }
 
 module.exports = QueryBuilder;

--- a/tests/query-builder-test.js
+++ b/tests/query-builder-test.js
@@ -255,28 +255,29 @@ describe('QueryBuilder', () => {
 			}
 		});
 
-		let params;
-
-		beforeEach(() => {
-			params = {};
-		});
+		const paramsBuilder = (params = {}) => {
+			params.joins = [randomTable];
+			return params;
+		};
 
 		context('when params are empty objects or trying to select All', () => {
 
 			it('Should return the same params object when params are empty', () => {
-				params = {};
+				const params = {};
 
 				assert.deepEqual(queryBuilder.prepareParams(params), params);
 			});
 
 			it('Should return empty object, ignoring joins when params only has joins key', () => {
-				params.joins = ['NpsTable'];
+				const params = {
+					joins: ['NpsTable']
+				};
 
 				assert.deepEqual(queryBuilder.prepareParams(params), {});
 			});
 
 			it('Should return the same params object when params only has \'fields: false\'', () => {
-				params = {
+				const params = {
 					fields: false
 				};
 
@@ -285,29 +286,27 @@ describe('QueryBuilder', () => {
 		});
 
 		context('when params have fields', () => {
-			params = {
-				joins: randomTable
-			};
-
-			let fields;
 
 			it('should return params with fields and no joins', () => {
-				fields = ['id', 'name'];
-				params.fields = fields;
+				const fields = ['id', 'name'];
+
+				const params = paramsBuilder({ fields });
 
 				assert.deepEqual(queryBuilder.prepareParams(params), { fields });
 			});
 
 			it('should return params with fields and joins with the table from fields', () => {
-				fields = ['id', 'name', 'profile'];
-				params.fields = fields;
+				const fields = ['id', 'name', 'profile'];
+
+				const params = paramsBuilder({ fields });
 
 				assert.deepEqual(queryBuilder.prepareParams(params), { fields, joins: [profileTable] });
 			});
 
 			it('should return params with fields and joins with the tables from fields ', () => {
-				fields = ['id', 'name', 'profile', 'client'];
-				params.fields = fields;
+				const fields = ['id', 'name', 'profile', 'client'];
+
+				const params = paramsBuilder({ fields });
 
 				assert.deepEqual(queryBuilder.prepareParams(params), { fields, joins: [profileTable, clientTable] });
 			});
@@ -316,43 +315,42 @@ describe('QueryBuilder', () => {
 
 		context('when params have group', () => {
 
-			params = {
-				joins: randomTable
-			};
-
-			let group;
-
 			it('should return params with group and no joins, using a single field', () => {
-				group = 'id';
-				params.group = group;
+				const group = 'id';
+
+				const params = paramsBuilder({ group });
 
 				assert.deepEqual(queryBuilder.prepareParams(params), { group });
 			});
 
 			it('should return params with group and joins, using a single field', () => {
-				group = 'profile';
-				params.group = group;
+				const group = 'profile';
+
+				const params = paramsBuilder({ group });
 
 				assert.deepEqual(queryBuilder.prepareParams(params), { group, joins: [profileTable] });
 			});
 
 			it('should return params with group and no joins, using multiple group by', () => {
-				group = ['id', 'name'];
-				params.group = group;
+				const group = ['id', 'name'];
+
+				const params = paramsBuilder({ group });
 
 				assert.deepEqual(queryBuilder.prepareParams(params), { group });
 			});
 
 			it('should return params with group and joins, using multiple group by', () => {
-				group = ['id', 'name', 'profile'];
-				params.group = group;
+				const group = ['id', 'name', 'profile'];
+
+				const params = paramsBuilder({ group });
 
 				assert.deepEqual(queryBuilder.prepareParams(params), { group, joins: [profileTable] });
 			});
 
 			it('should return params with group and joins, using multiple group by', () => {
-				group = ['id', 'name', 'profile', 'client'];
-				params.group = group;
+				const group = ['id', 'name', 'profile', 'client'];
+
+				const params = paramsBuilder({ group });
 
 				assert.deepEqual(queryBuilder.prepareParams(params), { group, joins: [profileTable, clientTable] });
 			});
@@ -360,56 +358,55 @@ describe('QueryBuilder', () => {
 		});
 
 		context('when params have order', () => {
-			params = {
-				joins: randomTable
-			};
-
-			let order;
 
 			it('should return params with order and no joins, using a single field', () => {
-				order = 'id';
-				params.order = order;
+				const order = 'id';
+
+				const params = paramsBuilder({ order });
 
 				assert.deepEqual(queryBuilder.prepareParams(params), { order });
 			});
 
 			it('should return params with order and joins, using a single field', () => {
-				order = 'profile';
-				params.order = order;
+				const order = 'profile';
+
+				const params = paramsBuilder({ order });
 
 				assert.deepEqual(queryBuilder.prepareParams(params), { order, joins: [profileTable] });
 			});
 
 			it('should return params with order and no joins, using multiple orders', () => {
-				order = {
+				const order = {
 					id: 'asc',
 					name: 'desc'
 				};
 
-				params.order = order;
+				const params = paramsBuilder({ order });
 
 				assert.deepEqual(queryBuilder.prepareParams(params), { order });
 			});
 
 			it('should return params with order and joins, using multiple orders', () => {
-				order = {
+				const order = {
 					id: 'asc',
 					name: 'desc',
 					profile: 'asc'
 				};
-				params.order = order;
+
+				const params = paramsBuilder({ order });
 
 				assert.deepEqual(queryBuilder.prepareParams(params), { order, joins: [profileTable] });
 			});
 
 			it('should return params with order and joins, using multiple orders and tables', () => {
-				order = {
+				const order = {
 					id: 'asc',
 					name: 'desc',
 					profile: 'asc',
 					client: 'desc'
 				};
-				params.order = order;
+
+				const params = paramsBuilder({ order });
 
 				assert.deepEqual(queryBuilder.prepareParams(params), { order, joins: [profileTable, clientTable] });
 			});
@@ -418,58 +415,57 @@ describe('QueryBuilder', () => {
 
 		context('when params have filters', () => {
 
-			params = {
-				joins: randomTable
-			};
-
-			let filters;
-
 			it('should return only filter without joins if fields don\'t required another table', () => {
-				filters = {
+				const filters = {
 					name: 'fizzmod'
 				};
-				params.filters = filters;
+
+				const params = paramsBuilder({ filters });
 
 				assert.deepEqual(queryBuilder.prepareParams(params), { filters });
 			});
 
 			it('should return only multiple filter without joins if fields don\'t required another table', () => {
-				filters = {
+				const filters = {
 					name: 'fizzmod',
 					id: { value: 10, type: 'greater' }
 				};
-				params.filters = filters;
+
+				const params = paramsBuilder({ filters });
 
 				assert.deepEqual(queryBuilder.prepareParams(params), { filters });
 			});
 
 			it('should return filter with joins if fields required another table', () => {
-				filters = {
+				const filters = {
 					profile: 1523
 				};
-				params.filters = filters;
+
+				const params = paramsBuilder({ filters });
 
 				assert.deepEqual(queryBuilder.prepareParams(params), { filters, joins: [profileTable] });
 			});
 
 			it('should return multiple filter with joins if fields required another table', () => {
-				filters = {
+				const filters = {
 					name: { value: 'Ar', type: 'search' },
 					profile: 1523,
 					client: { value: 2123312, type: 'lesser' }
 				};
-				params.filters = filters;
+
+				const params = paramsBuilder({ filters });
 
 				assert.deepEqual(queryBuilder.prepareParams(params), { filters, joins: [profileTable, clientTable] });
 			});
 
 			it('should return multiple filter with joins if fields required another table, using OR', () => {
-				filters = [
+				const filters = [
 					{ name: { value: 'Ar', type: 'search' } },
 					{ profile: 1523 },
 					{ client: { value: 2123312, type: 'lesser' } }
 				];
-				params.filters = filters;
+
+				const params = paramsBuilder({ filters });
 
 				assert.deepEqual(queryBuilder.prepareParams(params), { filters, joins: [profileTable, clientTable] });
 			});
@@ -478,50 +474,61 @@ describe('QueryBuilder', () => {
 
 		context('when params have special functions', () => {
 
-			let field;
+			['count', 'min', 'max', 'sum', 'avg'].forEach(specialFunction => {
+				describe(`${specialFunction}`, () => {
 
-			let result;
-
-			beforeEach(() => {
-				params = {
-					joins: randomTable
-				};
-
-				result = {};
-			});
-
-			['count', 'min', 'max', 'sum', 'avg'].forEach(spFun => {
-				describe(`${spFun}`, () => {
 					it('should return the function without joins if field no required another table', () => {
-						field = 'id';
-						params[spFun] = field;
+						const field = 'id';
 
-						result[spFun] = field;
+						const params = paramsBuilder();
+						params[specialFunction] = field;
+
+						const result = {};
+						result[specialFunction] = field;
 
 						assert.deepEqual(queryBuilder.prepareParams(params), result);
 					});
 
-					it('should return the function with joins if field required another table', () => {
-						field = 'profile';
-						params[spFun] = field;
+					it('should return the function without joins if function has bad format', () => {
+						const field = 'profile';
 
-						result[spFun] = field;
+						const params = paramsBuilder();
+						params[specialFunction] = [field];
+
+						const result = {};
+						result[specialFunction] = [field];
+
+						assert.deepEqual(queryBuilder.prepareParams(params), result);
+					});
+
+
+					it('should return the function with joins if field required another table', () => {
+						const field = 'profile';
+
+						const params = paramsBuilder();
+						params[specialFunction] = field;
+
+						const result = {};
+						result[specialFunction] = field;
 						result.joins = [profileTable];
 
 						assert.deepEqual(queryBuilder.prepareParams(params), result);
 					});
 
 					it('should return the function and alias without joins if field no required another table', () => {
-						field = 'id';
-						params[spFun] = {
+						const field = 'id';
+
+						const params = paramsBuilder();
+						params[specialFunction] = {
 							field,
-							alias: `${spFun}Function`
+							alias: `${specialFunction}Function`
 
 						};
 
-						result[spFun] = {
+						const result = {};
+						result[specialFunction] = {
 							field,
-							alias: `${spFun}Function`
+							alias: `${specialFunction}Function`
 
 						};
 
@@ -529,16 +536,19 @@ describe('QueryBuilder', () => {
 					});
 
 					it('should return the function and alias with joins if field required another table', () => {
-						field = 'profile';
-						params[spFun] = {
+						const field = 'profile';
+
+						const params = paramsBuilder();
+						params[specialFunction] = {
 							field,
-							alias: `${spFun}Function`
+							alias: `${specialFunction}Function`
 
 						};
 
-						result[spFun] = {
+						const result = {};
+						result[specialFunction] = {
 							field,
-							alias: `${spFun}Function`
+							alias: `${specialFunction}Function`
 
 						};
 						result.joins = [profileTable];

--- a/tests/query-builder-test.js
+++ b/tests/query-builder-test.js
@@ -239,6 +239,167 @@ describe('QueryBuilder', () => {
 		});
 	});
 
+	describe.only('Automatic Joins', () => {
+
+		const profileTable = 'ProfileTable';
+		const clientTable = 'ClientTable';
+		const randomTable = 'RandomTable';
+
+		const queryBuilder = queryBuilderFactory({
+			fields: {
+				id: true,
+				name: true,
+				profile: { table: profileTable },
+				client: { table: clientTable },
+				random: { table: randomTable },
+				storename: { table: clientTable }
+			}
+		});
+
+		let params;
+
+		beforeEach(() => {
+			params = {};
+		});
+
+		context('when params are empty objects or trying to select All', () => {
+
+			it('Should return the same params object when params are empty', () => {
+				params = {};
+
+				assert.deepEqual(queryBuilder.prepareParams(params), params);
+			});
+
+			it('Should return empty object, ignoring joins when params only has joins key', () => {
+				params.joins = ['NpsTable'];
+
+				assert.deepEqual(queryBuilder.prepareParams(params), {});
+			});
+
+			it('Should return the same params object when params only has \'fields: false\'', () => {
+				params = {
+					fields: false
+				};
+
+				assert.deepEqual(queryBuilder.prepareParams(params), params);
+			});
+		});
+
+		context('when params have fields', () => {
+			params = {
+				joins: randomTable
+			};
+
+			let fields;
+
+			it('should return params with fields and no joins', () => {
+				fields = ['id', 'name'];
+				params.fields = fields;
+
+				assert.deepEqual(queryBuilder.prepareParams(params), { fields });
+			});
+
+			it('should return params with fields and joins with the table from fields', () => {
+				fields = ['id', 'name', 'profile'];
+				params.fields = fields;
+
+				assert.deepEqual(queryBuilder.prepareParams(params), { fields, joins: [profileTable] });
+			});
+
+			it('should return params with fields and joins with the tables from fields ', () => {
+				fields = ['id', 'name', 'profile', 'client'];
+				params.fields = fields;
+
+				assert.deepEqual(queryBuilder.prepareParams(params), { fields, joins: [profileTable, clientTable] });
+			});
+
+		});
+
+		context('when params have order', () => {
+
+			params = {
+				joins: randomTable
+			};
+
+			let order;
+
+			it('should return params with order and no joins, using a single field', () => {
+				order = 'id';
+				params.order = order;
+
+				assert.deepEqual(queryBuilder.prepareParams(params), { order });
+			});
+
+			it('should return params with order and joins, using a single field', () => {
+				order = 'profile';
+				params.order = order;
+
+				assert.deepEqual(queryBuilder.prepareParams(params), { order, joins: [profileTable] });
+			});
+
+			it('should return params with order and no joins, using multiple orders', () => {
+				order = ['id', 'name'];
+				params.order = order;
+
+				assert.deepEqual(queryBuilder.prepareParams(params), { order });
+			});
+
+			it('should return params with order and joins, using multiple orders', () => {
+				order = ['id', 'name', 'profile'];
+				params.order = order;
+
+				assert.deepEqual(queryBuilder.prepareParams(params), { order, joins: [profileTable] });
+			});
+
+			it('should return params with order and joins, using multiple orders', () => {
+				order = ['id', 'name', 'profile', 'client'];
+				params.order = order;
+
+				assert.deepEqual(queryBuilder.prepareParams(params), { order, joins: [profileTable, clientTable] });
+			});
+
+		});
+
+		context('when params have group', () => {});
+
+		context('when params have filters', () => {});
+
+		context('when params have special functions', () => {});
+
+		context('when params have everything', () => {});
+
+
+		it('Should return the same params object when params are empty', () => {
+			params = {};
+
+			assert.deepEqual(queryBuilder.prepareParams(params), params);
+		});
+
+		it('Should return the same params object when params are empty', () => {
+			params = {};
+
+			assert.deepEqual(queryBuilder.prepareParams(params), params);
+		});
+
+		it('Should return the same params object when params are empty', () => {
+			params = {};
+
+			assert.deepEqual(queryBuilder.prepareParams(params), params);
+		});
+
+		it('Should return the same params object when params are empty', () => {
+			params = {};
+
+			assert.deepEqual(queryBuilder.prepareParams(params), params);
+		});
+
+		it('Should return the same params object when params are empty', () => {
+			params = {};
+
+			assert.deepEqual(queryBuilder.prepareParams(params), params);
+		});
+	});
+
 	describe('Get', () => {
 
 		it('Should return knexStatement', () => {

--- a/tests/query-builder-test.js
+++ b/tests/query-builder-test.js
@@ -144,7 +144,7 @@ describe('QueryBuilder', () => {
 
 	describe('Constructor', () => {
 
-		it('Should construct a QueryBuilder with base params', () => {
+		it('Should construct a QueryBuilder with base parameters', () => {
 
 			const fakeTable = 'fake_table';
 			const fakeFields = {
@@ -255,150 +255,150 @@ describe('QueryBuilder', () => {
 			}
 		});
 
-		const paramsBuilder = (params = {}) => {
-			params.joins = [randomTable];
-			return params;
+		const paramsBuilder = (parameters = {}) => {
+			parameters.joins = [randomTable];
+			return parameters;
 		};
 
-		context('when params are empty objects or trying to select All', () => {
+		context('when parameters are empty objects or trying to select All', () => {
 
-			it('Should return the same params object when params are empty', () => {
-				const params = {};
+			it('Should return the same parameters object when parameters are empty', () => {
+				const parameters = {};
 
-				assert.deepEqual(queryBuilder.prepareParams(params), params);
+				assert.deepEqual(queryBuilder.prepareParams(parameters), parameters);
 			});
 
-			it('Should return empty object, ignoring joins when params only has joins key', () => {
-				const params = {
+			it('Should return empty object, ignoring joins when parameters only has joins key', () => {
+				const parameters = {
 					joins: ['NpsTable']
 				};
 
-				assert.deepEqual(queryBuilder.prepareParams(params), {});
+				assert.deepEqual(queryBuilder.prepareParams(parameters), {});
 			});
 
-			it('Should return the same params object when params only has \'fields: false\'', () => {
-				const params = {
+			it('Should return the same parameters object when parameters only has \'fields: false\'', () => {
+				const parameters = {
 					fields: false
 				};
 
-				assert.deepEqual(queryBuilder.prepareParams(params), params);
+				assert.deepEqual(queryBuilder.prepareParams(parameters), parameters);
 			});
 		});
 
-		context('when params have fields', () => {
+		context('when parameters have fields', () => {
 
-			it('should return params with fields and no joins', () => {
+			it('should return parameters with fields and no joins', () => {
 				const fields = ['id', 'name'];
 
-				const params = paramsBuilder({ fields });
+				const parameters = paramsBuilder({ fields });
 
-				assert.deepEqual(queryBuilder.prepareParams(params), { fields });
+				assert.deepEqual(queryBuilder.prepareParams(parameters), { fields });
 			});
 
-			it('should return params with fields and joins with the table from fields', () => {
+			it('should return parameters with fields and joins with the table from fields', () => {
 				const fields = ['id', 'name', 'profile'];
 
-				const params = paramsBuilder({ fields });
+				const parameters = paramsBuilder({ fields });
 
-				assert.deepEqual(queryBuilder.prepareParams(params), { fields, joins: [profileTable] });
+				assert.deepEqual(queryBuilder.prepareParams(parameters), { fields, joins: [profileTable] });
 			});
 
-			it('should return params with fields and joins with the tables from fields ', () => {
+			it('should return parameters with fields and joins with the tables from fields ', () => {
 				const fields = ['id', 'name', 'profile', 'client'];
 
-				const params = paramsBuilder({ fields });
+				const parameters = paramsBuilder({ fields });
 
-				assert.deepEqual(queryBuilder.prepareParams(params), { fields, joins: [profileTable, clientTable] });
+				assert.deepEqual(queryBuilder.prepareParams(parameters), { fields, joins: [profileTable, clientTable] });
 			});
 
 		});
 
-		context('when params have group', () => {
+		context('when parameters have group', () => {
 
-			it('should return params with group and no joins, using a single field', () => {
+			it('should return parameters with group and no joins, using a single field', () => {
 				const group = 'id';
 
-				const params = paramsBuilder({ group });
+				const parameters = paramsBuilder({ group });
 
-				assert.deepEqual(queryBuilder.prepareParams(params), { group });
+				assert.deepEqual(queryBuilder.prepareParams(parameters), { group });
 			});
 
-			it('should return params with group and joins, using a single field', () => {
+			it('should return parameters with group and joins, using a single field', () => {
 				const group = 'profile';
 
-				const params = paramsBuilder({ group });
+				const parameters = paramsBuilder({ group });
 
-				assert.deepEqual(queryBuilder.prepareParams(params), { group, joins: [profileTable] });
+				assert.deepEqual(queryBuilder.prepareParams(parameters), { group, joins: [profileTable] });
 			});
 
-			it('should return params with group and no joins, using multiple group by', () => {
+			it('should return parameters with group and no joins, using multiple group by', () => {
 				const group = ['id', 'name'];
 
-				const params = paramsBuilder({ group });
+				const parameters = paramsBuilder({ group });
 
-				assert.deepEqual(queryBuilder.prepareParams(params), { group });
+				assert.deepEqual(queryBuilder.prepareParams(parameters), { group });
 			});
 
-			it('should return params with group and joins, using multiple group by', () => {
+			it('should return parameters with group and joins, using multiple group by', () => {
 				const group = ['id', 'name', 'profile'];
 
-				const params = paramsBuilder({ group });
+				const parameters = paramsBuilder({ group });
 
-				assert.deepEqual(queryBuilder.prepareParams(params), { group, joins: [profileTable] });
+				assert.deepEqual(queryBuilder.prepareParams(parameters), { group, joins: [profileTable] });
 			});
 
-			it('should return params with group and joins, using multiple group by', () => {
+			it('should return parameters with group and joins, using multiple group by', () => {
 				const group = ['id', 'name', 'profile', 'client'];
 
-				const params = paramsBuilder({ group });
+				const parameters = paramsBuilder({ group });
 
-				assert.deepEqual(queryBuilder.prepareParams(params), { group, joins: [profileTable, clientTable] });
+				assert.deepEqual(queryBuilder.prepareParams(parameters), { group, joins: [profileTable, clientTable] });
 			});
 
 		});
 
-		context('when params have order', () => {
+		context('when parameters have order', () => {
 
-			it('should return params with order and no joins, using a single field', () => {
+			it('should return parameters with order and no joins, using a single field', () => {
 				const order = 'id';
 
-				const params = paramsBuilder({ order });
+				const parameters = paramsBuilder({ order });
 
-				assert.deepEqual(queryBuilder.prepareParams(params), { order });
+				assert.deepEqual(queryBuilder.prepareParams(parameters), { order });
 			});
 
-			it('should return params with order and joins, using a single field', () => {
+			it('should return parameters with order and joins, using a single field', () => {
 				const order = 'profile';
 
-				const params = paramsBuilder({ order });
+				const parameters = paramsBuilder({ order });
 
-				assert.deepEqual(queryBuilder.prepareParams(params), { order, joins: [profileTable] });
+				assert.deepEqual(queryBuilder.prepareParams(parameters), { order, joins: [profileTable] });
 			});
 
-			it('should return params with order and no joins, using multiple orders', () => {
+			it('should return parameters with order and no joins, using multiple orders', () => {
 				const order = {
 					id: 'asc',
 					name: 'desc'
 				};
 
-				const params = paramsBuilder({ order });
+				const parameters = paramsBuilder({ order });
 
-				assert.deepEqual(queryBuilder.prepareParams(params), { order });
+				assert.deepEqual(queryBuilder.prepareParams(parameters), { order });
 			});
 
-			it('should return params with order and joins, using multiple orders', () => {
+			it('should return parameters with order and joins, using multiple orders', () => {
 				const order = {
 					id: 'asc',
 					name: 'desc',
 					profile: 'asc'
 				};
 
-				const params = paramsBuilder({ order });
+				const parameters = paramsBuilder({ order });
 
-				assert.deepEqual(queryBuilder.prepareParams(params), { order, joins: [profileTable] });
+				assert.deepEqual(queryBuilder.prepareParams(parameters), { order, joins: [profileTable] });
 			});
 
-			it('should return params with order and joins, using multiple orders and tables', () => {
+			it('should return parameters with order and joins, using multiple orders and tables', () => {
 				const order = {
 					id: 'asc',
 					name: 'desc',
@@ -406,23 +406,23 @@ describe('QueryBuilder', () => {
 					client: 'desc'
 				};
 
-				const params = paramsBuilder({ order });
+				const parameters = paramsBuilder({ order });
 
-				assert.deepEqual(queryBuilder.prepareParams(params), { order, joins: [profileTable, clientTable] });
+				assert.deepEqual(queryBuilder.prepareParams(parameters), { order, joins: [profileTable, clientTable] });
 			});
 
 		});
 
-		context('when params have filters', () => {
+		context('when parameters have filters', () => {
 
 			it('should return only filter without joins if fields don\'t required another table', () => {
 				const filters = {
 					name: 'fizzmod'
 				};
 
-				const params = paramsBuilder({ filters });
+				const parameters = paramsBuilder({ filters });
 
-				assert.deepEqual(queryBuilder.prepareParams(params), { filters });
+				assert.deepEqual(queryBuilder.prepareParams(parameters), { filters });
 			});
 
 			it('should return only multiple filter without joins if fields don\'t required another table', () => {
@@ -431,9 +431,9 @@ describe('QueryBuilder', () => {
 					id: { value: 10, type: 'greater' }
 				};
 
-				const params = paramsBuilder({ filters });
+				const parameters = paramsBuilder({ filters });
 
-				assert.deepEqual(queryBuilder.prepareParams(params), { filters });
+				assert.deepEqual(queryBuilder.prepareParams(parameters), { filters });
 			});
 
 			it('should return filter with joins if fields required another table', () => {
@@ -441,9 +441,9 @@ describe('QueryBuilder', () => {
 					profile: 1523
 				};
 
-				const params = paramsBuilder({ filters });
+				const parameters = paramsBuilder({ filters });
 
-				assert.deepEqual(queryBuilder.prepareParams(params), { filters, joins: [profileTable] });
+				assert.deepEqual(queryBuilder.prepareParams(parameters), { filters, joins: [profileTable] });
 			});
 
 			it('should return multiple filter with joins if fields required another table', () => {
@@ -453,9 +453,9 @@ describe('QueryBuilder', () => {
 					client: { value: 2123312, type: 'lesser' }
 				};
 
-				const params = paramsBuilder({ filters });
+				const parameters = paramsBuilder({ filters });
 
-				assert.deepEqual(queryBuilder.prepareParams(params), { filters, joins: [profileTable, clientTable] });
+				assert.deepEqual(queryBuilder.prepareParams(parameters), { filters, joins: [profileTable, clientTable] });
 			});
 
 			it('should return multiple filter with joins if fields required another table, using OR', () => {
@@ -465,14 +465,14 @@ describe('QueryBuilder', () => {
 					{ client: { value: 2123312, type: 'lesser' } }
 				];
 
-				const params = paramsBuilder({ filters });
+				const parameters = paramsBuilder({ filters });
 
-				assert.deepEqual(queryBuilder.prepareParams(params), { filters, joins: [profileTable, clientTable] });
+				assert.deepEqual(queryBuilder.prepareParams(parameters), { filters, joins: [profileTable, clientTable] });
 			});
 
 		});
 
-		context('when params have special functions', () => {
+		context('when parameters have special functions', () => {
 
 			['count', 'min', 'max', 'sum', 'avg'].forEach(specialFunction => {
 				describe(`${specialFunction}`, () => {
@@ -480,46 +480,46 @@ describe('QueryBuilder', () => {
 					it('should return the function without joins if field no required another table', () => {
 						const field = 'id';
 
-						const params = paramsBuilder();
-						params[specialFunction] = field;
+						const parameters = paramsBuilder();
+						parameters[specialFunction] = field;
 
 						const result = {};
 						result[specialFunction] = field;
 
-						assert.deepEqual(queryBuilder.prepareParams(params), result);
+						assert.deepEqual(queryBuilder.prepareParams(parameters), result);
 					});
 
 					it('should return the function without joins if function has bad format', () => {
 						const field = 'profile';
 
-						const params = paramsBuilder();
-						params[specialFunction] = [field];
+						const parameters = paramsBuilder();
+						parameters[specialFunction] = [field];
 
 						const result = {};
 						result[specialFunction] = [field];
 
-						assert.deepEqual(queryBuilder.prepareParams(params), result);
+						assert.deepEqual(queryBuilder.prepareParams(parameters), result);
 					});
 
 
 					it('should return the function with joins if field required another table', () => {
 						const field = 'profile';
 
-						const params = paramsBuilder();
-						params[specialFunction] = field;
+						const parameters = paramsBuilder();
+						parameters[specialFunction] = field;
 
 						const result = {};
 						result[specialFunction] = field;
 						result.joins = [profileTable];
 
-						assert.deepEqual(queryBuilder.prepareParams(params), result);
+						assert.deepEqual(queryBuilder.prepareParams(parameters), result);
 					});
 
 					it('should return the function and alias without joins if field no required another table', () => {
 						const field = 'id';
 
-						const params = paramsBuilder();
-						params[specialFunction] = {
+						const parameters = paramsBuilder();
+						parameters[specialFunction] = {
 							field,
 							alias: `${specialFunction}Function`
 
@@ -532,14 +532,14 @@ describe('QueryBuilder', () => {
 
 						};
 
-						assert.deepEqual(queryBuilder.prepareParams(params), result);
+						assert.deepEqual(queryBuilder.prepareParams(parameters), result);
 					});
 
 					it('should return the function and alias with joins if field required another table', () => {
 						const field = 'profile';
 
-						const params = paramsBuilder();
-						params[specialFunction] = {
+						const parameters = paramsBuilder();
+						parameters[specialFunction] = {
 							field,
 							alias: `${specialFunction}Function`
 
@@ -553,7 +553,7 @@ describe('QueryBuilder', () => {
 						};
 						result.joins = [profileTable];
 
-						assert.deepEqual(queryBuilder.prepareParams(params), result);
+						assert.deepEqual(queryBuilder.prepareParams(parameters), result);
 					});
 				});
 			});
@@ -588,8 +588,8 @@ describe('QueryBuilder', () => {
 		it('Should build normaly when debug mode on', () => {
 
 			const queryBuilder = queryBuilderFactory();
-			const params = { debug: true };
-			queryBuilder.get(params);
+			const parameters = { debug: true };
+			queryBuilder.get(parameters);
 		});
 	});
 


### PR DESCRIPTION
**JCN-125-joins-automaticos**
JCN-125 Joins Automaticos

**LINK AL TICKET**
https://fizzmod.atlassian.net/browse/JCN-125

**DESCRIPCIÓN DEL REQUERIMIENTO**
3.1. Se requiere que los joins se detecten automáticos dependiendo de los `fields`, `where`, `order`
3.2. Los joins no deben poder recibirse más (se deben ignorar)

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se desarrollo una función que busca en los parámetros si un campo tiene llamada a otra tabla, y se agrega la tabla a los parámetros para poder ser paseada luego por el builder de joins.
Pasar los joins por afuera ya no tendrá ningun efecto, se ignoran.
También busca para funciones especiales como `count`, `avg`, etc y para `group by`.