### PR TITLE
JCN 131 fix al selectear por flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+## Fixed
+- Filters for `flags` takes correct value
 
 ## [1.3.1] - 2019-08-06
 ## Fixed

--- a/docs/Fields.md
+++ b/docs/Fields.md
@@ -21,7 +21,7 @@ In the model must be an structured like this:
 
     static get flags() {
         return {
-            foo: 1
+            foo: { isActive: 1, error: 2 }
         }
     }
 ```

--- a/docs/Filters.md
+++ b/docs/Filters.md
@@ -337,46 +337,69 @@ Use `type` key in the `filter` object with some of these:
     select * from `table` as `t` where (`t`.`some` is not null);
     ```
 
-### Group by Fields
+## Flags
 
-Use `group` *key* to group by fields. It's SQL equivalent to `GROUP BY`.
+To filter by Flags, first it must be define on the *model*.
 
-* If a value is a *field name*, it's simple
+In the model: 
 
-    ```javascript
-    const parametres = {
-        filters: { 
-            group: 'some'
+```javascript
+    
+    static get fields() {
+        return {
+            foo: true
+        };
+    };
+
+    static get flags() {
+        return {
+            foo: { isActive: 1, error: 2 }
         }
     }
+```
 
-    const query = new QueryBuilder(knex, someModel);
-    const results = await query.get(parametres);
+Usage: 
+
+* For **false** match
+
+    ```javascript
+        const parametres = {
+            filters: { 
+                filters: {
+                    isActive: false // could be 0, '0' or 'false'
+                }
+            }
+        }
+
+        const query = new QueryBuilder(knex, someModel);
+        const results = await query.get(parametres);
     ```
 
     The query is :
 
     ```sql
-    select * from `table` as `t` group by `t`.`some`;
+        select * from `table` as `t` where  ((`t`.`foo` & 1) = 0);
     ```
 
-* If a value is a `Array` of *field name*, it's multiple
+* For **true** match
 
     ```javascript
-    const parametres = {
-        filters: { 
-            group: ['some', 'other']
+        const parametres = {
+            filters: { 
+                filters: {
+                    error: true // could be anything except 0, '0', false or 'false'
+                }
+            }
         }
-    }
 
-    const query = new QueryBuilder(knex, someModel);
-    const results = await query.get(parametres);
+        const query = new QueryBuilder(knex, someModel);
+        const results = await query.get(parametres);
     ```
 
     The query is :
 
     ```sql
-    select * from `table` as `t` group by `t`.`some`, `t`.`other`;
+        select * from `table` as `t` where  ((`t`.`foo` & 2) = 2);
     ```
 - - -
 

--- a/lib/query-builder-filters.js
+++ b/lib/query-builder-filters.js
@@ -228,7 +228,7 @@ class QueryBuilderFilters {
 		let value = filter.value || filter;
 
 		if(QueryBuilderFields._isFlagField(fieldName))
-			value = value ? QueryBuilderFields._getFlagData(fieldName).value : 0;
+			value = (typeof value !== 'undefined') ? value : QueryBuilderFields._getFlagData(fieldName).value;
 
 		return value;
 	}

--- a/lib/query-builder-filters.js
+++ b/lib/query-builder-filters.js
@@ -228,7 +228,7 @@ class QueryBuilderFilters {
 		let value = filter.value || filter;
 
 		if(QueryBuilderFields._isFlagField(fieldName))
-			value = (typeof value !== 'undefined') ? value : QueryBuilderFields._getFlagData(fieldName).value;
+			value = ['string', 'number', 'boolean'].includes(typeof value) ? value : QueryBuilderFields._getFlagData(fieldName).value;
 
 		return value;
 	}

--- a/lib/query-builder-filters.js
+++ b/lib/query-builder-filters.js
@@ -228,7 +228,7 @@ class QueryBuilderFilters {
 		let value = filter.value || filter;
 
 		if(QueryBuilderFields._isFlagField(fieldName))
-			value = ['string', 'number', 'boolean'].includes(typeof value) ? value : QueryBuilderFields._getFlagData(fieldName).value;
+			value = !value || value === '0' || value === 'false' ? 0 : QueryBuilderFields._getFlagData(fieldName).value;
 
 		return value;
 	}

--- a/tests/query-builder-filters-test.js
+++ b/tests/query-builder-filters-test.js
@@ -484,7 +484,7 @@ describe('Build Filters', () => {
 			assert.deepEqual(fakeKnex.where.args[0], ['t.foo', 'LIKE', '%foo%']);
 		});
 
-		it('Should call \'whereRaw\' knex method for flags filters', () => {
+		it('Should call \'whereRaw\' knex method for flags filters using 0', () => {
 
 			model = makeModel({
 				fields: {
@@ -510,6 +510,93 @@ describe('Build Filters', () => {
 			assert.equal(fakeKnex.whereRaw.callCount, 2);
 			assert.deepEqual(fakeKnex.whereRaw.args[0], ['(t.status & 1) = ?', '0']);
 			assert.deepEqual(fakeKnex.whereRaw.args[1], ['(t.status & 2) = ?', '0']);
+
+		});
+
+		it('Should call \'whereRaw\' knex method for flags filters using \'0\'', () => {
+
+			model = makeModel({
+				fields: {
+					status: true,
+					isActive: true,
+					error: true
+				},
+				flags: {
+					status: { isActive: 1, error: 2 }
+				}
+			});
+
+			params = {
+				filters: { isActive: '0', error: '0' }
+			};
+
+			QueryBuilderFilters.buildFilters(knex, model, params);
+
+			assert(knex.where.calledOnce);
+
+			const fakeKnex = callWhereCallback(knex);
+
+			assert.equal(fakeKnex.whereRaw.callCount, 2);
+			assert.deepEqual(fakeKnex.whereRaw.args[0], ['(t.status & 1) = ?', '0']);
+			assert.deepEqual(fakeKnex.whereRaw.args[1], ['(t.status & 2) = ?', '0']);
+
+		});
+
+		it('Should call \'whereRaw\' knex method for flags filters using \'false\' or false', () => {
+
+			model = makeModel({
+				fields: {
+					status: true,
+					isActive: true,
+					error: true
+				},
+				flags: {
+					status: { isActive: 1, error: 2 }
+				}
+			});
+
+			params = {
+				filters: { isActive: 'false', error: false }
+			};
+
+			QueryBuilderFilters.buildFilters(knex, model, params);
+
+			assert(knex.where.calledOnce);
+
+			const fakeKnex = callWhereCallback(knex);
+
+			assert.equal(fakeKnex.whereRaw.callCount, 2);
+			assert.deepEqual(fakeKnex.whereRaw.args[0], ['(t.status & 1) = ?', '0']);
+			assert.deepEqual(fakeKnex.whereRaw.args[1], ['(t.status & 2) = ?', '0']);
+
+		});
+
+		it('Should call \'whereRaw\' knex method for flags filters using other values', () => {
+
+			model = makeModel({
+				fields: {
+					status: true,
+					isActive: true,
+					error: true
+				},
+				flags: {
+					status: { isActive: 1, error: 2 }
+				}
+			});
+
+			params = {
+				filters: { isActive: 5, error: true }
+			};
+
+			QueryBuilderFilters.buildFilters(knex, model, params);
+
+			assert(knex.where.calledOnce);
+
+			const fakeKnex = callWhereCallback(knex);
+
+			assert.equal(fakeKnex.whereRaw.callCount, 2);
+			assert.deepEqual(fakeKnex.whereRaw.args[0], ['(t.status & 1) = ?', '1']);
+			assert.deepEqual(fakeKnex.whereRaw.args[1], ['(t.status & 2) = ?', '2']);
 
 		});
 	});

--- a/tests/query-builder-filters-test.js
+++ b/tests/query-builder-filters-test.js
@@ -470,7 +470,7 @@ describe('Build Filters', () => {
 			});
 
 			params = {
-				filters: { isActive: true, error: false }
+				filters: { isActive: 1, error: 0 }
 			};
 
 			QueryBuilderFilters.buildFilters(knex, model, params);

--- a/tests/query-builder-filters-test.js
+++ b/tests/query-builder-filters-test.js
@@ -163,6 +163,34 @@ describe('Build Filters', () => {
 				fields: { id: 'id' }
 			});
 		});
+		it('Should call \'whereRaw\' knex method for flags filters and setted default value in flags if are incorrect type', () => {
+
+			model = makeModel({
+				fields: {
+					status: true,
+					isActive: true,
+					error: true
+				},
+				flags: {
+					status: { isActive: 1, error: 2 }
+				}
+			});
+
+			params = {
+				filters: { isActive: {}, error: { value: [] } }
+			};
+
+			QueryBuilderFilters.buildFilters(knex, model, params);
+
+			assert(knex.where.calledOnce);
+
+			const fakeKnex = callWhereCallback(knex);
+
+			assert.equal(fakeKnex.whereRaw.callCount, 2);
+			assert.deepEqual(fakeKnex.whereRaw.args[0], ['(t.status & 1) = ?', '1']);
+			assert.deepEqual(fakeKnex.whereRaw.args[1], ['(t.status & 2) = ?', '2']);
+
+		});
 
 	});
 
@@ -470,7 +498,7 @@ describe('Build Filters', () => {
 			});
 
 			params = {
-				filters: { isActive: 1, error: 0 }
+				filters: { isActive: 0, error: 0 }
 			};
 
 			QueryBuilderFilters.buildFilters(knex, model, params);
@@ -480,7 +508,7 @@ describe('Build Filters', () => {
 			const fakeKnex = callWhereCallback(knex);
 
 			assert.equal(fakeKnex.whereRaw.callCount, 2);
-			assert.deepEqual(fakeKnex.whereRaw.args[0], ['(t.status & 1) = ?', '1']);
+			assert.deepEqual(fakeKnex.whereRaw.args[0], ['(t.status & 1) = ?', '0']);
 			assert.deepEqual(fakeKnex.whereRaw.args[1], ['(t.status & 2) = ?', '0']);
 
 		});


### PR DESCRIPTION
**JCN 131-FIX-AL-SELECTEAR-POR-FLAGS**
JCN-131 fix al selectear por flags

**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JCN-131

**DESCRIPCIÓN DEL REQUERIMIENTO**
5.1. Se requiere mejorar los filtros por flags, actualmente no esta tomando el valor obtenido en los filtros, sino que aplica siempre el valor de la flag declarada en el modelo
5.2. Se deberá poder filtrar por alguna flag, en donde el value pueda ser 1 y/o 0. ej WHERE (t.flags & 1) = 1) o WHERE (t.flags & 1) = 0)

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se arregló el código donde no tomaba el valor correcto.