### PR TITLE
JCN 147-MySQL-debe-estandarizar-fechas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- `Update` modified `date_modified`
 
 ## [1.3.2] - 2019-08-08
 ## Fixed

--- a/lib/query-builder.js
+++ b/lib/query-builder.js
@@ -11,12 +11,17 @@ const QueryBuilderGroup = require('./query-builder-group');
 const QueryBuilderOrder = require('./query-builder-order');
 const QueryBuilderPagination = require('./query-builder-pagination');
 
-const DATE_FIELDS = ['date_modified', 'date_created'];
+const DATE_CREATED = 'date_created';
+const DATE_MODIFIED = 'date_modified';
 
 class QueryBuilder {
 
+	static get dateModified() {
+		return DATE_MODIFIED;
+	}
+
 	static get dateFields() {
-		return DATE_FIELDS;
+		return [DATE_CREATED, DATE_MODIFIED];
 	}
 
 	/**
@@ -155,6 +160,8 @@ class QueryBuilder {
 			if(tableFields.includes(field))
 				validFields[`t.${field}`] = values[field];
 		});
+
+		validFields[`t.${this.constructor.dateModified}`] = (Date.now() / 1000 | 0);
 
 		return validFields;
 


### PR DESCRIPTION
**JCN 147-MySQL-debe-estandarizar-fechas**
JCN 147 MySQL debe estandarizar fechas

**LINK AL TICKET**
https://fizzmod.atlassian.net/browse/JCN-147

**DESCRIPCIÓN DEL REQUERIMIENTO**
1.1 - Modificar si corresponde  el driver de `MySQL` para que contenga `dateCreated` para las fechas de creación de un elemento nuevo.
1.2 - Modificar si corresponde  el driver de `MySQL` para que contenga `dateModified` para las fechas de edición de un elemento existente.

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se agrego que `update` actualice la fecha de modificación (que no lo hacia). El resto cumplia.