### PR TITLE
JCN-query builder fix insert fields

### DIFF
--- a/lib/query-builder.js
+++ b/lib/query-builder.js
@@ -10,6 +10,7 @@ const QueryBuilderFilters = require('./query-builder-filters');
 const QueryBuilderGroup = require('./query-builder-group');
 const QueryBuilderOrder = require('./query-builder-order');
 const QueryBuilderPagination = require('./query-builder-pagination');
+const { convertToSnakeCase, convertToCamelCase } = require('./utils');
 
 const DATE_CREATED = 'date_created';
 const DATE_MODIFIED = 'date_modified';
@@ -118,7 +119,7 @@ class QueryBuilder {
 			const validFields = {};
 
 			tableFields.forEach(field => {
-				validFields[field] = item[field] || (this.constructor.dateFields.includes(field) ? time : null);
+				validFields[field] = item[convertToCamelCase(field)] || (this.constructor.dateFields.includes(field) ? time : null);
 			});
 
 			return validFields;
@@ -157,7 +158,7 @@ class QueryBuilder {
 		const validFields = {};
 
 		valuesFields.forEach(field => {
-			if(tableFields.includes(field))
+			if(tableFields.includes(convertToSnakeCase(field)))
 				validFields[`t.${field}`] = values[field];
 		});
 

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -13,6 +13,22 @@ const Utils = {
 	 */
 	arrayUnique(items = []) {
 		return items.filter((item, index) => items.indexOf(item) === index);
+	},
+	/**
+	*	Convert a string to camelCase
+	*	@param {string} The string to convert
+	* @return {string} The modfied string
+	*/
+	convertToCamelCase(str) {
+		return str.replace(/_([a-z])/g, letter => letter[1].toUpperCase());
+	},
+	/**
+	*	Convert a string to snake_case
+	*	@param {string} The string to convert
+	* @return {string} The modfied string
+	*/
+	convertToSnakeCase(str) {
+		return str.replace(/[A-Z]/g, letter => `_${letter.toLowerCase()}`);
 	}
 };
 

--- a/tests/utils-test.js
+++ b/tests/utils-test.js
@@ -19,4 +19,16 @@ describe('Utils', function() {
 			assert.deepEqual(Utils.arrayUnique([]), []);
 		});
 	});
+
+	describe('Should convert string to snake_case', function() {
+		assert.equal(Utils.convertToSnakeCase('orderFormId'), 'order_form_id');
+		assert.equal(Utils.convertToSnakeCase('checkBoolean'), 'check_boolean');
+		assert.equal(Utils.convertToSnakeCase('status'), 'status');
+	});
+
+	describe('Should convert string to camelCamse', function() {
+		assert.equal(Utils.convertToCamelCase('order_formId'), 'orderFormId');
+		assert.equal(Utils.convertToCamelCase('check_boolean'), 'checkBoolean');
+		assert.equal(Utils.convertToCamelCase('status'), 'status');
+	});
 });


### PR DESCRIPTION
**JCN-QUERY-BUILDER-FIX-INSERT-FIELDS**
JCN - query builder fix insert fields

**DESCRIPCIÓN DEL REQUERIMIENTO**
Corregir que al `insert` un Elemento los campos en camelCase no se insertar correctamente.

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se realizaron los desarrollos solicitados. Y se arregló mismo problema en `update`