### PR TITLE
[QUICK] JCN Fix Format Fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `_formatFields` method name to `_getFormatFields`
 
 ### Fixed
-- Non-undefined falsy values can be iserted/saved
+- Non-undefined falsies values can be iserted/saved
 
 
 ## [1.3.4] - 2019-09-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- `_formatFields` method name to `_getFormatFields`
+
+### Fixed
+- Non-undefined falsy values can be iserted/saved
+
 
 ## [1.3.4] - 2019-09-06
 ### Changed

--- a/lib/query-builder.js
+++ b/lib/query-builder.js
@@ -120,7 +120,7 @@ class QueryBuilder {
 
 			tableFields.forEach(field => {
 
-				if(item[convertToCamelCase(field)] !== 'undefined')
+				if(item[convertToCamelCase(field)] !== undefined)
 					validFields[field] = item[convertToCamelCase(field)];
 				else
 					validFields[field] = this.constructor.dateFields.includes(field) ? time : null;

--- a/lib/query-builder.js
+++ b/lib/query-builder.js
@@ -108,7 +108,7 @@ class QueryBuilder {
 	 * @param {Array<objects>} items Array of Objects
 	 */
 
-	async _formatFields(items) {
+	async _getFormatFields(items) {
 
 		const tableFields = Object.keys(await this._getFields());
 
@@ -119,7 +119,11 @@ class QueryBuilder {
 			const validFields = {};
 
 			tableFields.forEach(field => {
-				validFields[field] = item[convertToCamelCase(field)] || (this.constructor.dateFields.includes(field) ? time : null);
+
+				if(item[convertToCamelCase(field)] !== 'undefined')
+					validFields[field] = item[convertToCamelCase(field)];
+				else
+					validFields[field] = this.constructor.dateFields.includes(field) ? time : null;
 			});
 
 			return validFields;
@@ -198,7 +202,7 @@ class QueryBuilder {
 				throw new QueryBuilderError('Not valid items to Insert', QueryBuilderError.codes.NO_ITEMS);
 		}
 		// Format Items to have valid fields
-		items = await this._formatFields(items);
+		items = await this._getFormatFields(items);
 
 		try {
 			return this.knexStatement.insert(items);
@@ -227,7 +231,7 @@ class QueryBuilder {
 				throw new QueryBuilderError('Not valid items to Save', QueryBuilderError.codes.NO_ITEMS);
 		}
 		// Format Items to have valid fields
-		items = await this._formatFields(items);
+		items = await this._getFormatFields(items);
 
 		try {
 


### PR DESCRIPTION
**[QUICK] JCN Fix Format Fields**
JCN Fix Format Fields

**DESCRIPCIÓN DEL REQUERIMIENTO**

* Cambiar nombre de la función `_formatFields` a `_getFormatFields`
* Corregir validación para que se puedan guardar valores como `0` o `''` ('falsy') que no sean `undefined`