### PR TITLE
JCN-172-query-builder-estatico

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- static class helpers are now instanteable to avoid errors when using from multiple origins in the same execution.
+
 ## [1.3.5] - 2019-09-11
 ### Changed
 - `_formatFields` method name to `_getFormatFields`

--- a/lib/query-builder-fields.js
+++ b/lib/query-builder-fields.js
@@ -18,7 +18,7 @@ class QueryBuilderSelect {
 	 * Initialize the necesary data to use the Builder
 	 * @param {instance} model Model to be used
 	 */
-	static initModel(model) {
+	constructor(model) {
 
 		this.modelName = model.constructor.name;
 		this.fields = model.constructor.fields;
@@ -32,7 +32,7 @@ class QueryBuilderSelect {
 	 * @param {object} modelFields Model fields
 	 * @returns {array}
 	 */
-	static getJoinsFields({ fields }, modelFields) {
+	getJoinsFields({ fields }, modelFields) {
 		if(!fields || !Array.isArray(fields))
 			return [];
 
@@ -45,8 +45,8 @@ class QueryBuilderSelect {
 	 * @param {object} modelFields Model fields
 	 * @returns {array}
 	 */
-	static getJoinsSpecialFunction(parameters, modelFields) {
-		const specialFunctions = Object.keys(this.selectFunctions)
+	getJoinsSpecialFunction(parameters, modelFields) {
+		const specialFunctions = Object.keys(this.constructor.selectFunctions)
 			.filter(specialFunction => parameters[specialFunction]);
 
 		const fields = specialFunctions.map(specialFunction => {
@@ -68,16 +68,13 @@ class QueryBuilderSelect {
 	 * @param {instance} model
 	 * @param {object} parameters
 	 */
-	static buildSelect(knex, model, parameters) {
+	buildSelect(knex, model, parameters) {
 
 		if(!knex)
 			throw new QueryBuilderError('Invalid Knex', QueryBuilderError.codes.INVALID_KNEX);
 
 		if(!model)
 			throw new QueryBuilderError('Invalid Model', QueryBuilderError.codes.INVALID_MODEL);
-
-
-		this.initModel(model);
 
 		this.parameters = parameters;
 
@@ -136,7 +133,7 @@ class QueryBuilderSelect {
 	 * @param {array} fields The fields
 	 * @return {boolean} true if valid, throw otherwise
 	 */
-	static _validateFields(fields) {
+	_validateFields(fields) {
 
 		fields.forEach(field => {
 			if(!this._validateField(field))
@@ -152,7 +149,7 @@ class QueryBuilderSelect {
 	 * @param {string} fieldName The field name
 	 * @return {boolean} true if valid, false otherwise
 	 */
-	static _validateField(fieldName) {
+	_validateField(fieldName) {
 
 		if(!this._fieldExists(fieldName)) {
 			this.error = new QueryBuilderError(`Unknown field '${fieldName}', check ${this.modelName}.fields`, QueryBuilderError.codes.INVALID_FIELDS);
@@ -168,8 +165,8 @@ class QueryBuilderSelect {
 	 * @param {string} fieldName The field name
 	 * @return {Boolean} true if exists, false otherwise
 	 */
-	static _fieldExists(fieldName) {
-		return typeof this.fields[fieldName] !== 'undefined';
+	_fieldExists(fieldName) {
+		return this.fields && typeof this.fields[fieldName] !== 'undefined';
 	}
 
 	/**
@@ -177,7 +174,7 @@ class QueryBuilderSelect {
 	 *
 	 * @return {Array} The flag fields.
 	 */
-	static _getFlagFields() {
+	_getFlagFields() {
 
 		if(typeof this.flags === 'undefined')
 			return [];
@@ -196,7 +193,7 @@ class QueryBuilderSelect {
 	 * @param {array} fields The fields
 	 * @return {object|false} The fields for select, or false if empty
 	 */
-	static _getFieldsForSelect(fields) {
+	_getFieldsForSelect(fields) {
 
 		const fieldsForSelect = {};
 
@@ -217,7 +214,7 @@ class QueryBuilderSelect {
 	 * @param {string} fieldName The field name
 	 * @return {boolean} True if flag field, False otherwise.
 	 */
-	static _isFlagField(fieldName) {
+	_isFlagField(fieldName) {
 
 		const flagData = this._getFlagData(fieldName);
 
@@ -231,7 +228,7 @@ class QueryBuilderSelect {
 	 * @param {string} fieldName The field name
 	 * @return {(Object|false)} The flag data or false if not a flag.
 	 */
-	static _getFlagData(fieldName) {
+	_getFlagData(fieldName) {
 
 		if(typeof this.flags === 'undefined')
 			return false;
@@ -257,7 +254,7 @@ class QueryBuilderSelect {
 	 * @param {string} fieldName The field name
 	 * @return {string} The alias for select.
 	 */
-	static _getAliasForSelect(fieldName) {
+	_getAliasForSelect(fieldName) {
 		return typeof this.fields[fieldName] === 'object' && this.fields[fieldName].alias ? this.fields[fieldName].alias : fieldName;
 	}
 
@@ -267,7 +264,7 @@ class QueryBuilderSelect {
 	 * @param {string} fieldName The field name
 	 * @return {string} The formatted field.
 	 */
-	static _getFormattedField(fieldName) {
+	_getFormattedField(fieldName) {
 
 		if(this._isFlagField(fieldName))
 			return this._getFormattedFlagField(fieldName);
@@ -281,7 +278,7 @@ class QueryBuilderSelect {
 	 * @param {string} fieldName The field name
 	 * @return {string} The table alias.
 	 */
-	static _getTableAliasFromField(fieldName) {
+	_getTableAliasFromField(fieldName) {
 
 		if(typeof this.fields[fieldName] !== 'object')
 			return 't';
@@ -300,7 +297,7 @@ class QueryBuilderSelect {
 	 * @param {string} fieldName The field name
 	 * @return {string} The real field name.
 	 */
-	static _getRealFieldName(fieldName) {
+	_getRealFieldName(fieldName) {
 
 		const field = this.fields[fieldName];
 
@@ -316,7 +313,7 @@ class QueryBuilderSelect {
 		return fieldName;
 	}
 
-	static _getFlagFieldsForSelect(fields) {
+	_getFlagFieldsForSelect(fields) {
 
 		const flagFieldsForSelect = {};
 
@@ -333,7 +330,7 @@ class QueryBuilderSelect {
 		return Object.keys(flagFieldsForSelect).length ? flagFieldsForSelect : false;
 	}
 
-	static _getFormattedFlagField(fieldName) {
+	_getFormattedFlagField(fieldName) {
 
 		const { field, value } = this._getFlagData(fieldName);
 
@@ -345,11 +342,11 @@ class QueryBuilderSelect {
 	 *
 	 * @return {(Object|boolean)} The select functions.
 	 */
-	static _getSelectFunctions() {
+	_getSelectFunctions() {
 
 		const selectFunctions = [];
 
-		for(const [selectFunction, selectMethod] of Object.entries(this.selectFunctions)) {
+		for(const [selectFunction, selectMethod] of Object.entries(this.constructor.selectFunctions)) {
 
 			if(!this.parameters[selectFunction])
 				continue;

--- a/lib/query-builder-filters.js
+++ b/lib/query-builder-filters.js
@@ -26,11 +26,13 @@ class QueryBuilderFilters {
 	 * Initialize the necesary data to use the Builder
 	 * @param {instance} model Model to be used
 	 */
-	static initModel(model) {
+	constructor(model) {
 
 		this.modelName = model.constructor.name;
 		this.fields = model.constructor.fields;
 		this.flags = model.constructor.flags;
+
+		this.queryBuilderFields = new QueryBuilderFields(model);
 	}
 
 	/**
@@ -39,7 +41,7 @@ class QueryBuilderFilters {
 	 * @param {object} modelFields Model fields
 	 * @returns {array}
 	 */
-	static getJoinsFields({ filters }, modelFields) {
+	getJoinsFields({ filters }, modelFields) {
 		if(!filters)
 			return [];
 
@@ -57,17 +59,12 @@ class QueryBuilderFilters {
 	/**
 	 * Builds filters. Add AND or OR filters.
 	 */
-	static buildFilters(knex, model, parameters) {
+	buildFilters(knex, model, parameters) {
 		if(!knex)
 			throw new QueryBuilderError('Invalid Knex', QueryBuilderError.codes.INVALID_KNEX);
 
 		if(!model)
 			throw new QueryBuilderError('Invalid Model', QueryBuilderError.codes.INVALID_MODEL);
-
-
-		this.initModel(model);
-
-		QueryBuilderFields.initModel(model);
 
 		// eslint-disable-next-line prefer-destructuring
 		const filters = parameters.filters;
@@ -86,7 +83,7 @@ class QueryBuilderFilters {
 	 *
 	 * @param {object} filters The filters
 	 */
-	static _addOrFilters(filters, knex) {
+	_addOrFilters(filters, knex) {
 		knex.orWhere(builder => this._makeFilters(builder, filters));
 	}
 
@@ -95,7 +92,7 @@ class QueryBuilderFilters {
 	 *
 	 * @param {object} filters The filters
 	 */
-	static _addAndFilters(filters, knex) {
+	_addAndFilters(filters, knex) {
 		knex.where(builder => this._makeFilters(builder, filters));
 	}
 
@@ -105,7 +102,7 @@ class QueryBuilderFilters {
 	 * @param {function} builder The Knex builder callback
 	 * @param {object} filters The filters
 	 */
-	static _makeFilters(builder, filters) {
+	_makeFilters(builder, filters) {
 
 		for(const [fieldName, filter] of Object.entries(filters)) {
 
@@ -127,9 +124,9 @@ class QueryBuilderFilters {
 	 * @param {mixed} filter The filter content, value or object with definition
 	 * @return {boolean} True if filter is valid, false otherwise
 	 */
-	static _validateFilter(fieldName, filter) {
+	_validateFilter(fieldName, filter) {
 
-		if(!QueryBuilderFields._validateField(fieldName, this.fields)) {
+		if(!this.queryBuilderFields._validateField(fieldName, this.fields)) {
 			this.error = new QueryBuilderError(`Unknown field '${fieldName}', check ${this.modelName}.fields`, QueryBuilderError.codes.INVALID_FIELDS);
 			return false;
 		}
@@ -150,7 +147,7 @@ class QueryBuilderFilters {
 			return false;
 		}
 
-		const { needMultipleValues } = this.filterTypes[filterType];
+		const { needMultipleValues } = this.constructor.filterTypes[filterType];
 
 		if(needMultipleValues) {
 
@@ -181,9 +178,9 @@ class QueryBuilderFilters {
 	 * @param {object} filter The filter data
 	 * @return {string} The filter type.
 	 */
-	static _getFilterType(fieldName, filter) {
+	_getFilterType(fieldName, filter) {
 
-		if(QueryBuilderFields._isFlagField(fieldName))
+		if(this.queryBuilderFields._isFlagField(fieldName))
 			return 'flagEqual';
 
 		if(typeof filter === 'object' && filter.type)
@@ -201,8 +198,8 @@ class QueryBuilderFilters {
 	 * @param {string} filterType The filter type
 	 * @return {boolean} True if filter exists, false otherwise
 	 */
-	static _filterTypeExists(filterType) {
-		return filterType && typeof filterType === 'string' && this.filterTypes[filterType];
+	_filterTypeExists(filterType) {
+		return filterType && typeof filterType === 'string' && this.constructor.filterTypes[filterType];
 	}
 
 	/**
@@ -212,7 +209,7 @@ class QueryBuilderFilters {
 	 * @param {mixed} filter The filter content or value
 	 * @return {boolean} true if is multiple, false otherwise
 	 */
-	static _filterIsMultiple(fieldName, filter) {
+	_filterIsMultiple(fieldName, filter) {
 		return Array.isArray(this._getFilterValue(fieldName, filter));
 	}
 
@@ -223,12 +220,12 @@ class QueryBuilderFilters {
 	 * @param {mixed} filter The filter content or value
 	 * @return {mixed} The filter value.
 	 */
-	static _getFilterValue(fieldName, filter) {
+	_getFilterValue(fieldName, filter) {
 
 		let value = filter.value || filter;
 
-		if(QueryBuilderFields._isFlagField(fieldName))
-			value = !value || value === '0' || value === 'false' ? 0 : QueryBuilderFields._getFlagData(fieldName).value;
+		if(this.queryBuilderFields._isFlagField(fieldName))
+			value = !value || value === '0' || value === 'false' ? 0 : this.queryBuilderFields._getFlagData(fieldName).value;
 
 		return value;
 	}
@@ -240,7 +237,7 @@ class QueryBuilderFilters {
 	 * @param {mixed} filter The filter content or value
 	 * @return {mixed} filter value
 	 */
-	static _prepareFilterValue(fieldName, filter) {
+	_prepareFilterValue(fieldName, filter) {
 
 		const filterType = this._getFilterType(fieldName, filter);
 		const valuePrefix = this._getFilterValuePrefix(filterType);
@@ -267,8 +264,8 @@ class QueryBuilderFilters {
 	 * @param {string} filterType The filter type
 	 * @return {boolean} True if filter allows multiple values, false otherwise
 	 */
-	static _filterTypeAllowsMultipleValues(filterType) {
-		return this._filterTypeExists(filterType) && this.filterTypes[filterType].multipleValues;
+	_filterTypeAllowsMultipleValues(filterType) {
+		return this._filterTypeExists(filterType) && this.constructor.filterTypes[filterType].multipleValues;
 	}
 
 	/**
@@ -277,8 +274,8 @@ class QueryBuilderFilters {
 	 * @param {string} filterType The filter type
 	 * @return {boolean} True if should add filter value, false otherwise
 	 */
-	static _filterNeedsValue(filterType) {
-		return this._filterTypeExists(filterType) && !this.filterTypes[filterType].noValueNeeded;
+	_filterNeedsValue(filterType) {
+		return this._filterTypeExists(filterType) && !this.constructor.filterTypes[filterType].noValueNeeded;
 	}
 
 	/**
@@ -287,9 +284,9 @@ class QueryBuilderFilters {
 	 * @param {string} filterType The filter type
 	 * @return {string|boolean} The filter value prefix if any, false otherwise
 	 */
-	static _getFilterValuePrefix(filterType) {
-		return this._filterTypeExists(filterType) && this.filterTypes[filterType].valuePrefix ?
-			this.filterTypes[filterType].valuePrefix : false;
+	_getFilterValuePrefix(filterType) {
+		return this._filterTypeExists(filterType) && this.constructor.filterTypes[filterType].valuePrefix ?
+			this.constructor.filterTypes[filterType].valuePrefix : false;
 	}
 
 	/**
@@ -298,9 +295,9 @@ class QueryBuilderFilters {
 	 * @param {string} filterType The filter type
 	 * @return {string|boolean} The filter value suffix if any, false otherwise
 	 */
-	static _getFilterValueSuffix(filterType) {
-		return this._filterTypeExists(filterType) && this.filterTypes[filterType].valueSuffix ?
-			this.filterTypes[filterType].valueSuffix : false;
+	_getFilterValueSuffix(filterType) {
+		return this._filterTypeExists(filterType) && this.constructor.filterTypes[filterType].valueSuffix ?
+			this.constructor.filterTypes[filterType].valueSuffix : false;
 	}
 
 	/**
@@ -310,16 +307,16 @@ class QueryBuilderFilters {
 	 * @param {object} filter The filter data
 	 * @return {string} The filter Knex method name.
 	 */
-	static _getFilterMethod(fieldName, filter) {
+	_getFilterMethod(fieldName, filter) {
 
 		const filterType = this._getFilterType(fieldName, filter);
 
 		const isMultiple = this._filterIsMultiple(fieldName, filter);
 
 		if(isMultiple)
-			return this.filterTypes[filterType].multipleMethod;
+			return this.constructor.filterTypes[filterType].multipleMethod;
 
-		return this.filterTypes[filterType].method || 'where';
+		return this.constructor.filterTypes[filterType].method || 'where';
 	}
 
 	/**
@@ -329,13 +326,13 @@ class QueryBuilderFilters {
 	 * @param {mixed} filter The filter data
 	 * @return {Array} The filter parameters.
 	 */
-	static _getFilterParams(fieldName, filter) {
+	_getFilterParams(fieldName, filter) {
 
 		const filterParams = [
-			QueryBuilderFields._getFormattedField(fieldName)
+			this.queryBuilderFields._getFormattedField(fieldName)
 		];
 
-		if(QueryBuilderFields._isFlagField(fieldName))
+		if(this.queryBuilderFields._isFlagField(fieldName))
 			filterParams[0] += ' = ?';
 
 		const filterType = this._getFilterType(fieldName, filter);
@@ -357,8 +354,8 @@ class QueryBuilderFilters {
 	 * @param {string} filterType The filter type
 	 * @return {(boolean|string)} The filter operator is any, false otherwise
 	 */
-	static _getFilterOperator(filterType) {
-		return this.filterTypes[filterType].operator || false;
+	_getFilterOperator(filterType) {
+		return this.constructor.filterTypes[filterType].operator || false;
 	}
 }
 

--- a/lib/query-builder-group.js
+++ b/lib/query-builder-group.js
@@ -10,12 +10,11 @@ class QueryBuilderGroup {
 	 * Initialize the necesary data to use the Builder
 	 * @param {instance} model Model to be used
 	 */
-	static initModel(model) {
-		// If the Builder was init before and with the same model, don't init again.
-		if(this.modelName && this.modelName === model.constructor.name)
-			return;
+	constructor(model) {
 
 		this.modelName = model.constructor.name;
+
+		this.queryBuilderFields = new QueryBuilderFields(model);
 	}
 
 	/**
@@ -24,7 +23,7 @@ class QueryBuilderGroup {
 	 * @param {object} modelFields Model fields
 	 * @returns {array}
 	 */
-	static getJoinsFields({ group }, modelFields) {
+	getJoinsFields({ group }, modelFields) {
 		if(!group || (typeof group === 'object' && !Array.isArray(group)))
 			return [];
 
@@ -35,22 +34,15 @@ class QueryBuilderGroup {
 	/**
 	 * Builds group by function.
 	 * @param {object} knex must have key 'knexStatement' with knex function
-	 * @param {instance} model
 	 * @param {object} parameters
 	 */
-	static buildGroup(knex, model, parameters) {
+	buildGroup(knex, model, parameters) {
 
 		if(!knex)
 			throw new QueryBuilderError('Invalid Knex', QueryBuilderError.codes.INVALID_KNEX);
 
 		if(!model)
 			throw new QueryBuilderError('Invalid Model', QueryBuilderError.codes.INVALID_MODEL);
-
-		this.initModel(model);
-
-		// To Build the Orders needs to validate Fields
-		// Need to Init Builder Fields if it's not
-		QueryBuilderFields.initModel(model);
 
 		// eslint-disable-next-line prefer-destructuring
 		let group = parameters.group;
@@ -73,9 +65,9 @@ class QueryBuilderGroup {
 			if(!this._validateGroupItem(fieldName))
 				throw this.error;
 
-			const formattedField = QueryBuilderFields._getFormattedField(fieldName);
+			const formattedField = this.queryBuilderFields._getFormattedField(fieldName);
 
-			if(QueryBuilderFields._isFlagField(fieldName))
+			if(this.queryBuilderFields._isFlagField(fieldName))
 				knex.groupByRaw(formattedField);
 			else
 				knex.groupBy(formattedField);
@@ -88,9 +80,9 @@ class QueryBuilderGroup {
 	 * @param {string} fieldName The field name
 	 * @return {boolean} true if valid, false otherwise
 	 */
-	static _validateGroupItem(fieldName) {
+	_validateGroupItem(fieldName) {
 
-		if(!QueryBuilderFields._validateField(fieldName)) {
+		if(!this.queryBuilderFields._validateField(fieldName)) {
 			this.error = new QueryBuilderError(`Unknown field '${fieldName}', check ${this.modelName}.fields`, QueryBuilderError.codes.INVALID_FIELDS);
 			return false;
 		}

--- a/lib/query-builder-joins.js
+++ b/lib/query-builder-joins.js
@@ -34,7 +34,6 @@ class QueryBuilderJoins {
 		this.modelName = model.constructor.name;
 		this.joins = model.constructor.joins;
 		this.modelName = model.constructor.name;
-		this.model = model;
 
 		this.queryBuilderFields = new QueryBuilderFields(model);
 	}

--- a/lib/query-builder-joins.js
+++ b/lib/query-builder-joins.js
@@ -29,12 +29,14 @@ class QueryBuilderJoins {
 	 * Initialize the necesary data to use the Builder
 	 * @param {instance} model Model to be used
 	 */
-	static initModel(model) {
+	constructor(model) {
 
 		this.modelName = model.constructor.name;
 		this.joins = model.constructor.joins;
 		this.modelName = model.constructor.name;
 		this.model = model;
+
+		this.queryBuilderFields = new QueryBuilderFields(model);
 	}
 
 	/**
@@ -43,19 +45,13 @@ class QueryBuilderJoins {
 	 * @param {instance} model
 	 * @param {object} parameters
 	 */
-	static buildJoins(knex, model, parameters) {
+	buildJoins(knex, model, parameters) {
 
 		if(!knex)
 			throw new QueryBuilderError('Invalid Knex', QueryBuilderError.codes.INVALID_KNEX);
 
 		if(!model)
 			throw new QueryBuilderError('Invalid Model', QueryBuilderError.codes.INVALID_MODEL);
-
-		this.initModel(model);
-
-		// To Build the Orders needs to validate Fields
-		// Need to Init Builder Fields if it's not
-		QueryBuilderFields.initModel(model);
 
 		const { joins } = parameters;
 
@@ -73,7 +69,7 @@ class QueryBuilderJoins {
 	 *
 	 * @param {string} joinKey The join key
 	 */
-	static _makeJoin(joinKey, knex) {
+	_makeJoin(joinKey, knex) {
 
 		if(!this._validateJoin(joinKey))
 			throw this.error;
@@ -107,7 +103,7 @@ class QueryBuilderJoins {
 	 * @param {string} joinKey The join key
 	 * @return {boolean} true if valid, false otherwise
 	 */
-	static _validateJoin(joinKey) {
+	_validateJoin(joinKey) {
 
 		if(!this._joinExists(joinKey)) {
 			this.error = new QueryBuilderError(`Unknown joinKey '${joinKey}', check ${this.modelName}.joins`,
@@ -153,7 +149,7 @@ class QueryBuilderJoins {
 	 * @param {string} joinKey The join key
 	 * @return {Boolean} true if exists, false otherwise
 	 */
-	static _joinExists(joinKey) {
+	_joinExists(joinKey) {
 		return typeof this.joins[joinKey] !== 'undefined';
 	}
 
@@ -163,8 +159,8 @@ class QueryBuilderJoins {
 	 * @param {string} joinMethod The join method
 	 * @return {Boolean} true if exists, false otherwise
 	 */
-	static _joinMethodExists(joinMethod) {
-		return typeof this.joinMethods[joinMethod] !== 'undefined';
+	_joinMethodExists(joinMethod) {
+		return typeof this.constructor.joinMethods[joinMethod] !== 'undefined';
 	}
 
 	/**
@@ -173,9 +169,9 @@ class QueryBuilderJoins {
 	 * @param {string} operator The join operator
 	 * @return {boolear} true if valid operator, false otherwise
 	 */
-	static _validateJoinOperator(operator) {
+	_validateJoinOperator(operator) {
 
-		if(!this.joinOperators.includes(operator)) {
+		if(!this.constructor.joinOperators.includes(operator)) {
 			this.error = new QueryBuilderError(`Unknown join operator '${operator}'`,
 				QueryBuilderError.codes.INVALID_JOINS);
 			return false;
@@ -191,7 +187,7 @@ class QueryBuilderJoins {
 	 * @param {string} type The type
 	 * @return {boolean} true if valid, false otherwise
 	 */
-	static _validateJoinOn(joinKey, type = 'on') {
+	_validateJoinOn(joinKey, type = 'on') {
 
 		const on = this.joins[joinKey][type];
 
@@ -229,7 +225,7 @@ class QueryBuilderJoins {
 	 * @param {array} joinFields the join fields
 	 * @return {boolean} true if valid fields, false otherwise
 	 */
-	static _validateJoinFields(joinKey, joinFields) {
+	_validateJoinFields(joinKey, joinFields) {
 
 		if(joinFields.length !== 2 && joinFields.length !== 3) {
 			this.error = new QueryBuilderError(`join '${joinKey}' parts 'on' and 'orOn' must have 2 o 3 values, check ${this.modelName}.joins.${joinKey}`,
@@ -246,11 +242,11 @@ class QueryBuilderJoins {
 		else
 			[fieldA, operator, fieldB] = joinFields;
 
-		const isValidFields = QueryBuilderFields._validateField(fieldA)
-			&& !QueryBuilderFields._isFlagField(fieldA)
+		const isValidFields = this.queryBuilderFields._validateField(fieldA)
+			&& !this.queryBuilderFields._isFlagField(fieldA)
 			&& this._validateJoinOperator(operator)
-			&& QueryBuilderFields._validateField(fieldB)
-			&& !QueryBuilderFields._isFlagField(fieldB);
+			&& this.queryBuilderFields._validateField(fieldB)
+			&& !this.queryBuilderFields._isFlagField(fieldB);
 
 		if(!isValidFields)
 			this.error = new QueryBuilderError(`Unknown fields, check ${this.modelName}.fields`, QueryBuilderError.codes.INVALID_FIELDS);
@@ -264,9 +260,9 @@ class QueryBuilderJoins {
 	 * @param {string} joinKey The join key
 	 * @return {string} The join method.
 	 */
-	static _getJoinMethod(joinKey) {
+	_getJoinMethod(joinKey) {
 		const joinMethod = this.joins[joinKey].method || JOIN_DEFAULT_METHOD;
-		return this.joinMethods[joinMethod];
+		return this.constructor.joinMethods[joinMethod];
 	}
 
 	/**
@@ -275,7 +271,7 @@ class QueryBuilderJoins {
 	 * @param {string} joinKey The join key
 	 * @return {string} The join table.
 	 */
-	static _getJoinTable(joinKey) {
+	_getJoinTable(joinKey) {
 		const modelJoin = this.joins[joinKey];
 		const table = modelJoin.table || joinKey;
 		return `${table} as ${modelJoin.alias}`;
@@ -287,9 +283,10 @@ class QueryBuilderJoins {
 	 * @param {array} joinFields The join fields
 	 * @return {array} The formatted join fields.
 	 */
-	static _getFormattedJoinFields(joinFields) {
+	_getFormattedJoinFields(joinFields) {
+
 		return joinFields.map(joinField => {
-			return QueryBuilderFields._fieldExists(joinField) ? QueryBuilderFields._getFormattedField(joinField) : joinField;
+			return this.queryBuilderFields._fieldExists(joinField) ? this.queryBuilderFields._getFormattedField(joinField) : joinField;
 		});
 	}
 

--- a/lib/query-builder-order.js
+++ b/lib/query-builder-order.js
@@ -6,12 +6,23 @@ const QueryBuilderFields = require('./query-builder-fields');
 class QueryBuilderOrder {
 
 	/**
+	 * Initialize the necesary data to use the Builder
+	 * @param {instance} model Model to be used
+	 */
+	constructor(model) {
+
+		this.modelName = model.constructor.name;
+
+		this.queryBuilderFields = new QueryBuilderFields(model);
+	}
+
+	/**
 	 * Search in the order parameters and return fields that have to join on a table
 	 * @param {object} parameters parameters
 	 * @param {object} modelFields Model fields
 	 * @returns {array}
 	 */
-	static getJoinsFields({ order }, modelFields) {
+	getJoinsFields({ order }, modelFields) {
 		if(!order || (typeof order === 'object' && Array.isArray(order)))
 			return [];
 
@@ -24,18 +35,13 @@ class QueryBuilderOrder {
      * @param {object} knex must have key 'knexStatement' with knex function
 	 * @param {object} parameters
 	 */
-	static buildOrder(knex, model, parameters) {
+	buildOrder(knex, model, parameters) {
+
 		if(!knex)
 			throw new QueryBuilderError('Invalid Knex', QueryBuilderError.codes.INVALID_KNEX);
 
 		if(!model)
 			throw new QueryBuilderError('Invalid Model', QueryBuilderError.codes.INVALID_MODEL);
-
-		this.modelName = model.constructor.name;
-
-		// To Build the Orders needs to validate Fields
-		// Need to Init Builder Fields if it's not
-		QueryBuilderFields.initModel(model);
 
 		// eslint-disable-next-line prefer-destructuring
 		let order = parameters.order;
@@ -54,9 +60,9 @@ class QueryBuilderOrder {
 			if(!this._validateOrderItem(fieldName, direction))
 				throw this.error;
 
-			const formattedField = QueryBuilderFields._getFormattedField(fieldName);
+			const formattedField = this.queryBuilderFields._getFormattedField(fieldName);
 
-			if(QueryBuilderFields._isFlagField(fieldName))
+			if(this.queryBuilderFields._isFlagField(fieldName))
 				knex.orderByRaw(`${formattedField} ${direction}`);
 			else
 				knex.orderBy(formattedField, direction);
@@ -71,9 +77,9 @@ class QueryBuilderOrder {
 	 * @param {string} direction The order by direction (asc, desc)
 	 * @return {boolean} true if valid, false otherwise
 	 */
-	static _validateOrderItem(fieldName, direction) {
+	_validateOrderItem(fieldName, direction) {
 
-		if(!QueryBuilderFields._validateField(fieldName)) {
+		if(!this.queryBuilderFields._validateField(fieldName)) {
 			this.error = new QueryBuilderError(`Unknown field '${fieldName}', check ${this.modelName}.fields`, QueryBuilderError.codes.INVALID_FIELDS);
 			return false;
 		}

--- a/lib/query-builder.js
+++ b/lib/query-builder.js
@@ -44,6 +44,13 @@ class QueryBuilder {
 
 		this.table = model.constructor.table;
 		this.fields = model.constructor.fields || {};
+
+		this.queryBuilderSelect = new QueryBuilderSelect(model);
+		this.queryBuilderFilters = new QueryBuilderFilters(model);
+		this.queryBuilderOrder = new QueryBuilderOrder(model);
+		this.queryBuilderJoins = new QueryBuilderJoins(model);
+		this.queryBuilderGroup = new QueryBuilderGroup(model);
+		this.queryBuilderPagination = QueryBuilderPagination;
 	}
 
 	/**
@@ -85,17 +92,17 @@ class QueryBuilder {
 
 		this._init();
 
-		QueryBuilderSelect.buildSelect(this.knexStatement, this.model, this.parameters);
+		this.queryBuilderSelect.buildSelect(this.knexStatement, this.model, this.parameters);
 
 		if(this._modelHasFieldsStructure()) {
-			QueryBuilderJoins.buildJoins(this.knexStatement, this.model, this.parameters);
-			QueryBuilderFilters.buildFilters(this.knexStatement, this.model, this.parameters);
-			QueryBuilderOrder.buildOrder(this.knexStatement, this.model, this.parameters);
-			QueryBuilderGroup.buildGroup(this.knexStatement, this.model, this.parameters);
+			this.queryBuilderJoins.buildJoins(this.knexStatement, this.model, this.parameters);
+			this.queryBuilderFilters.buildFilters(this.knexStatement, this.model, this.parameters);
+			this.queryBuilderOrder.buildOrder(this.knexStatement, this.model, this.parameters);
+			this.queryBuilderGroup.buildGroup(this.knexStatement, this.model, this.parameters);
 		} else
 			logger.warn('QueryBuilder - No fields structure');
 
-		QueryBuilderPagination.buildLimit(this.knexStatement, this.parameters);
+		this.queryBuilderPagination.buildLimit(this.knexStatement, this.parameters);
 
 		if(this.parameters.debug)
 			logger.info('statement', this.knexStatement.toString());
@@ -264,7 +271,7 @@ class QueryBuilder {
 
 		values = await this._formatUpdateValues(values);
 		try {
-			QueryBuilderFilters.buildFilters(this.knexStatement, this.model, this.parameters);
+			this.queryBuilderFilters.buildFilters(this.knexStatement, this.model, this.parameters);
 			return this.knexStatement.update(values);
 
 		} catch(error) {
@@ -289,9 +296,9 @@ class QueryBuilder {
 		try {
 
 			// Builds the Filters (Where)
-			QueryBuilderFilters.buildFilters(this.knexStatement, this.model, this.parameters);
+			this.queryBuilderFilters.buildFilters(this.knexStatement, this.model, this.parameters);
 			// Builds the Joins
-			QueryBuilderJoins.buildJoins(this.knexStatement, this.model, this.parameters);
+			this.queryBuilderJoins.buildJoins(this.knexStatement, this.model, this.parameters);
 			// Necesary to use Knex, otherwise fails.
 			const deleteQuereyRaw = this._changeQueryTableAlias(this.knexStatement.del().toString());
 
@@ -350,11 +357,11 @@ class QueryBuilder {
 
 		// Filter the parameters which have a join option
 		const fields = [
-			...QueryBuilderSelect.getJoinsFields(parameters, this.fields),
-			...QueryBuilderSelect.getJoinsSpecialFunction(parameters, this.fields),
-			...QueryBuilderFilters.getJoinsFields(parameters, this.fields),
-			...QueryBuilderOrder.getJoinsFields(parameters, this.fields),
-			...QueryBuilderGroup.getJoinsFields(parameters, this.fields)
+			...this.queryBuilderSelect.getJoinsFields(parameters, this.fields),
+			...this.queryBuilderSelect.getJoinsSpecialFunction(parameters, this.fields),
+			...this.queryBuilderFilters.getJoinsFields(parameters, this.fields),
+			...this.queryBuilderOrder.getJoinsFields(parameters, this.fields),
+			...this.queryBuilderGroup.getJoinsFields(parameters, this.fields)
 		];
 
 		// Get Unique Tables

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@janiscommerce/query-builder",
-  "version": "1.3.3",
+  "version": "1.3.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/tests/query-builder-fields-test.js
+++ b/tests/query-builder-fields-test.js
@@ -47,7 +47,18 @@ const makeModel = ({
 
 	}
 
-	return new FakeModel();
+	return new FakeModel({
+		id: true
+	});
+};
+
+let queryBuilderFields;
+
+const makeQueryBuilder = model => {
+	if(!model)
+		queryBuilderFields = new QueryBuilderFields(makeModel({}));
+	else
+		queryBuilderFields = new QueryBuilderFields(model);
 };
 
 describe('Build Group', () => {
@@ -59,6 +70,7 @@ describe('Build Group', () => {
 
 		beforeEach(() => {
 			knex = makeKnex();
+			makeQueryBuilder();
 		});
 
 		afterEach(() => {
@@ -67,13 +79,13 @@ describe('Build Group', () => {
 
 		it('should return QueryBuilderError if no params is passed', () => {
 
-			assert.throws(() => QueryBuilderFields.buildSelect(), { code: QueryBuilderError.codes.INVALID_KNEX });
+			assert.throws(() => queryBuilderFields.buildSelect(), { code: QueryBuilderError.codes.INVALID_KNEX });
 
 		});
 
 		it('should return QueryBuilderError if no Model is passed', () => {
 
-			assert.throws(() => QueryBuilderFields.buildSelect(knex), { code: QueryBuilderError.codes.INVALID_MODEL });
+			assert.throws(() => queryBuilderFields.buildSelect(knex), { code: QueryBuilderError.codes.INVALID_MODEL });
 
 		});
 
@@ -83,6 +95,7 @@ describe('Build Group', () => {
 
 		beforeEach(() => {
 			knex = makeKnex();
+			makeQueryBuilder();
 		});
 
 		afterEach(() => {
@@ -97,7 +110,9 @@ describe('Build Group', () => {
 
 			params = { fields: false, count: true };
 
-			QueryBuilderFields.buildSelect(knex, model, params);
+			makeQueryBuilder(model);
+
+			queryBuilderFields.buildSelect(knex, model, params);
 
 			assert(knex.select.notCalled);
 		});
@@ -108,7 +123,7 @@ describe('Build Group', () => {
 
 			params = {};
 
-			QueryBuilderFields.buildSelect(knex, model, params);
+			queryBuilderFields.buildSelect(knex, model, params);
 
 			assert(knex.count.notCalled);
 		});
@@ -121,7 +136,9 @@ describe('Build Group', () => {
 
 			params = { fields: 'id' };
 
-			assert.throws(() => QueryBuilderFields.buildSelect(knex, model, params), { code: QueryBuilderError.codes.INVALID_FIELDS });
+			makeQueryBuilder(model);
+
+			assert.throws(() => queryBuilderFields.buildSelect(knex, model, params), { code: QueryBuilderError.codes.INVALID_FIELDS });
 
 			assert(knex.select.notCalled);
 		});
@@ -134,7 +151,9 @@ describe('Build Group', () => {
 
 			params = { fields: ['bar'] };
 
-			assert.throws(() => QueryBuilderFields.buildSelect(knex, model, params), { code: QueryBuilderError.codes.INVALID_FIELDS });
+			makeQueryBuilder(model);
+
+			assert.throws(() => queryBuilderFields.buildSelect(knex, model, params), { code: QueryBuilderError.codes.INVALID_FIELDS });
 
 			assert(knex.select.notCalled);
 		});
@@ -145,7 +164,7 @@ describe('Build Group', () => {
 
 			params = { fields: ['id'] };
 
-			assert.throws(() => QueryBuilderFields.buildSelect(knex, model, params), { code: QueryBuilderError.codes.INVALID_FIELDS });
+			assert.throws(() => queryBuilderFields.buildSelect(knex, model, params), { code: QueryBuilderError.codes.INVALID_FIELDS });
 
 			assert(!knex.select.called);
 		});
@@ -156,7 +175,7 @@ describe('Build Group', () => {
 
 			params = { fields: [] };
 
-			assert.throws(() => QueryBuilderFields.buildSelect(knex, model, params), { code: QueryBuilderError.codes.NOTHING_SELECT });
+			assert.throws(() => queryBuilderFields.buildSelect(knex, model, params), { code: QueryBuilderError.codes.NOTHING_SELECT });
 
 			assert(!knex.select.called);
 		});
@@ -167,7 +186,7 @@ describe('Build Group', () => {
 
 			params = { fields: false };
 
-			assert.throws(() => QueryBuilderFields.buildSelect(knex, model, params), { code: QueryBuilderError.codes.NOTHING_SELECT });
+			assert.throws(() => queryBuilderFields.buildSelect(knex, model, params), { code: QueryBuilderError.codes.NOTHING_SELECT });
 
 			assert(!knex.select.called);
 		});
@@ -178,7 +197,7 @@ describe('Build Group', () => {
 
 			params = { count: 'unknown' };
 
-			assert.throws(() => QueryBuilderFields.buildSelect(knex, model, params), { code: QueryBuilderError.codes.INVALID_FIELDS });
+			assert.throws(() => queryBuilderFields.buildSelect(knex, model, params), { code: QueryBuilderError.codes.INVALID_FIELDS });
 
 			assert(knex.count.notCalled);
 		});
@@ -200,7 +219,7 @@ describe('Build Group', () => {
 
 				params = { count: invalidCount };
 
-				assert.throws(() => QueryBuilderFields.buildSelect(knex, model, params), { code: QueryBuilderError.codes.INVALID_SELECT_FUNCTION });
+				assert.throws(() => queryBuilderFields.buildSelect(knex, model, params), { code: QueryBuilderError.codes.INVALID_SELECT_FUNCTION });
 
 				assert(knex.count.notCalled);
 			});
@@ -222,7 +241,9 @@ describe('Build Group', () => {
 				fields: ['isActive']
 			};
 
-			assert.throws(() => QueryBuilderFields.buildSelect(knex, model, params), { code: QueryBuilderError.codes.INVALID_FIELDS });
+			makeQueryBuilder(model);
+
+			assert.throws(() => queryBuilderFields.buildSelect(knex, model, params), { code: QueryBuilderError.codes.INVALID_FIELDS });
 
 			assert(!knex.select.called);
 		});
@@ -247,7 +268,9 @@ describe('Build Group', () => {
 
 			params = { fields: ['id'] };
 
-			QueryBuilderFields.buildSelect(knex, model, params);
+			makeQueryBuilder(model);
+
+			queryBuilderFields.buildSelect(knex, model, params);
 
 			assert(knex.select.called);
 			assert.deepEqual(knex.select.args[0][0], { id: 't.id' });
@@ -261,7 +284,9 @@ describe('Build Group', () => {
 
 			params = { fields: ['foo'] };
 
-			QueryBuilderFields.buildSelect(knex, model, params);
+			makeQueryBuilder(model);
+
+			queryBuilderFields.buildSelect(knex, model, params);
 
 			assert(knex.select.called);
 			assert.deepEqual(knex.select.args[0][0], { foo: 't.bar' });
@@ -275,7 +300,9 @@ describe('Build Group', () => {
 
 			params = { fields: ['foo'] };
 
-			QueryBuilderFields.buildSelect(knex, model, params);
+			makeQueryBuilder(model);
+
+			queryBuilderFields.buildSelect(knex, model, params);
 
 			assert(knex.select.called);
 			assert.deepEqual(knex.select.args[0][0], { greatAlias: 't.bar' });
@@ -287,7 +314,7 @@ describe('Build Group', () => {
 
 			params = {};
 
-			QueryBuilderFields.buildSelect(knex, model, params);
+			queryBuilderFields.buildSelect(knex, model, params);
 
 			assert(knex.select.calledOnce);
 			assert.deepEqual(knex.select.args[0][0], 't.*');
@@ -301,7 +328,9 @@ describe('Build Group', () => {
 
 			params = {};
 
-			QueryBuilderFields.buildSelect(knex, model, params);
+			makeQueryBuilder(model);
+
+			queryBuilderFields.buildSelect(knex, model, params);
 
 			assert(knex.select.calledOnce);
 			assert.deepEqual(knex.select.args[0][0], 't.*');
@@ -316,7 +345,9 @@ describe('Build Group', () => {
 
 			params = {};
 
-			QueryBuilderFields.buildSelect(knex, model, params);
+			makeQueryBuilder(model);
+
+			queryBuilderFields.buildSelect(knex, model, params);
 
 			assert(knex.select.calledTwice);
 
@@ -336,7 +367,9 @@ describe('Build Group', () => {
 
 			params = { noFlags: true };
 
-			QueryBuilderFields.buildSelect(knex, model, params);
+			makeQueryBuilder(model);
+
+			queryBuilderFields.buildSelect(knex, model, params);
 
 			assert(knex.select.calledOnce);
 
@@ -358,7 +391,9 @@ describe('Build Group', () => {
 
 			params = { fields: ['isActive'] };
 
-			QueryBuilderFields.buildSelect(knex, model, params);
+			makeQueryBuilder(model);
+
+			queryBuilderFields.buildSelect(knex, model, params);
 
 			assert(knex.select.called);
 			assert(knex.raw.called);
@@ -382,12 +417,18 @@ describe('Build Group', () => {
 				fields: ['status']
 			};
 
-			QueryBuilderFields.buildSelect(knex, model, params);
+			makeQueryBuilder(model);
+
+			queryBuilderFields.buildSelect(knex, model, params);
 
 			assert(knex.select.calledOnce);
 		});
 
 		describe('select Functions', () => {
+
+			beforeEach(() => {
+				makeQueryBuilder();
+			});
 
 			const selectFunctions = ['count', 'min', 'max', 'sum', 'avg'];
 
@@ -399,7 +440,7 @@ describe('Build Group', () => {
 
 					params = { [selectFunction]: true };
 
-					QueryBuilderFields.buildSelect(knex, model, params);
+					queryBuilderFields.buildSelect(knex, model, params);
 
 					assert(knex[selectFunction].calledOnce);
 					assert.deepEqual(knex[selectFunction].args[0], [`* as ${selectFunction}`]);
@@ -414,7 +455,9 @@ describe('Build Group', () => {
 
 					params = { [selectFunction]: 'id' };
 
-					QueryBuilderFields.buildSelect(knex, model, params);
+					makeQueryBuilder(model);
+
+					queryBuilderFields.buildSelect(knex, model, params);
 
 					assert(knex[selectFunction].calledOnce);
 					assert.deepEqual(knex[selectFunction].args[0], [`t.id as ${selectFunction}`]);
@@ -429,7 +472,9 @@ describe('Build Group', () => {
 
 					params = { [selectFunction]: { field: 'id' } };
 
-					QueryBuilderFields.buildSelect(knex, model, params);
+					makeQueryBuilder(model);
+
+					queryBuilderFields.buildSelect(knex, model, params);
 
 					assert(knex[selectFunction].calledOnce);
 					assert.deepEqual(knex[selectFunction].args[0], [`t.id as ${selectFunction}`]);
@@ -442,7 +487,7 @@ describe('Build Group', () => {
 
 					params = { [selectFunction]: { alias: `${selectFunction}Alias` } };
 
-					QueryBuilderFields.buildSelect(knex, model, params);
+					queryBuilderFields.buildSelect(knex, model, params);
 
 					assert(knex[selectFunction].calledOnce);
 					assert.deepEqual(knex[selectFunction].args[0], [`* as ${selectFunction}Alias`]);
@@ -457,7 +502,9 @@ describe('Build Group', () => {
 
 					params = { [selectFunction]: { field: 'id', alias: `${selectFunction}Alias` } };
 
-					QueryBuilderFields.buildSelect(knex, model, params);
+					makeQueryBuilder(model);
+
+					queryBuilderFields.buildSelect(knex, model, params);
 
 					assert(knex[selectFunction].calledOnce);
 					assert.deepEqual(knex[selectFunction].args[0], [`t.id as ${selectFunction}Alias`]);

--- a/tests/query-builder-filters-test.js
+++ b/tests/query-builder-filters-test.js
@@ -50,6 +50,15 @@ const makeModel = ({
 	return new FakeModel();
 };
 
+let queryBuilderFilters;
+
+const makeQueryBuilder = model => {
+	if(!model)
+		queryBuilderFilters = new QueryBuilderFilters(makeModel({}));
+	else
+		queryBuilderFilters = new QueryBuilderFilters(model);
+};
+
 describe('Build Filters', () => {
 	let knex;
 	let model;
@@ -71,6 +80,7 @@ describe('Build Filters', () => {
 	context('when no Knex function or Model is passed', () => {
 
 		beforeEach(() => {
+			makeQueryBuilder();
 			knex = makeKnex();
 		});
 
@@ -80,13 +90,13 @@ describe('Build Filters', () => {
 
 		it('should return QueryBuilderError if no params is passed', () => {
 
-			assert.throws(() => QueryBuilderFilters.buildFilters(), { code: QueryBuilderError.codes.INVALID_KNEX });
+			assert.throws(() => queryBuilderFilters.buildFilters(), { code: QueryBuilderError.codes.INVALID_KNEX });
 
 		});
 
 		it('should return QueryBuilderError if no Model is passed', () => {
 
-			assert.throws(() => QueryBuilderFilters.buildFilters(knex), { code: QueryBuilderError.codes.INVALID_MODEL });
+			assert.throws(() => queryBuilderFilters.buildFilters(knex), { code: QueryBuilderError.codes.INVALID_MODEL });
 
 		});
 
@@ -100,13 +110,16 @@ describe('Build Filters', () => {
 
 			params = param;
 
-			QueryBuilderFilters.buildFilters(knex, model, params);
+			makeQueryBuilder(model);
+
+			queryBuilderFilters.buildFilters(knex, model, params);
 
 			assert(knex.where.calledOnce);
 			assert.throws(() => { callWhereCallback(knex); }, QueryBuilderError);
 		};
 
 		beforeEach(() => {
+			makeQueryBuilder();
 			knex = makeKnex();
 		});
 
@@ -119,7 +132,7 @@ describe('Build Filters', () => {
 
 			params = {};
 
-			QueryBuilderFilters.buildFilters(knex, model, params);
+			queryBuilderFilters.buildFilters(knex, model, params);
 
 			assert(knex.where.notCalled);
 		});
@@ -128,7 +141,7 @@ describe('Build Filters', () => {
 
 			params = {};
 
-			QueryBuilderFilters.buildFilters(knex, model, params);
+			queryBuilderFilters.buildFilters(knex, model, params);
 
 			assert(knex.where.notCalled);
 		});
@@ -180,7 +193,9 @@ describe('Build Filters', () => {
 				filters: { isActive: {}, error: { value: [] } }
 			};
 
-			QueryBuilderFilters.buildFilters(knex, model, params);
+			makeQueryBuilder(model);
+
+			queryBuilderFilters.buildFilters(knex, model, params);
 
 			assert(knex.where.calledOnce);
 
@@ -212,7 +227,9 @@ describe('Build Filters', () => {
 				fields: { id: 'id' }
 			});
 
-			QueryBuilderFilters.buildFilters(knex, model, params);
+			makeQueryBuilder(model);
+
+			queryBuilderFilters.buildFilters(knex, model, params);
 
 			assert(knex.where.calledOnce);
 
@@ -229,7 +246,9 @@ describe('Build Filters', () => {
 
 			model = makeModel({ fields });
 
-			QueryBuilderFilters.buildFilters(knex, model, params);
+			makeQueryBuilder(model);
+
+			queryBuilderFilters.buildFilters(knex, model, params);
 
 			assert(knex.where.calledOnce);
 
@@ -246,7 +265,9 @@ describe('Build Filters', () => {
 
 			model = makeModel({ fields });
 
-			QueryBuilderFilters.buildFilters(knex, model, params);
+			makeQueryBuilder(model);
+
+			queryBuilderFilters.buildFilters(knex, model, params);
 
 			assert(knex.orWhere.calledOnce);
 
@@ -265,7 +286,9 @@ describe('Build Filters', () => {
 
 			model = makeModel({ fields });
 
-			QueryBuilderFilters.buildFilters(knex, model, params);
+			makeQueryBuilder(model);
+
+			queryBuilderFilters.buildFilters(knex, model, params);
 
 			assert(knex.orWhere.calledTwice);
 
@@ -287,7 +310,9 @@ describe('Build Filters', () => {
 
 			model = makeModel({ fields });
 
-			QueryBuilderFilters.buildFilters(knex, model, params);
+			makeQueryBuilder(model);
+
+			queryBuilderFilters.buildFilters(knex, model, params);
 
 			assert(knex.where.calledOnce);
 
@@ -304,7 +329,9 @@ describe('Build Filters', () => {
 
 			model = makeModel({ fields });
 
-			QueryBuilderFilters.buildFilters(knex, model, params);
+			makeQueryBuilder(model);
+
+			queryBuilderFilters.buildFilters(knex, model, params);
 
 			assert(knex.where.calledOnce);
 
@@ -321,7 +348,9 @@ describe('Build Filters', () => {
 
 			model = makeModel({ fields });
 
-			QueryBuilderFilters.buildFilters(knex, model, params);
+			makeQueryBuilder(model);
+
+			queryBuilderFilters.buildFilters(knex, model, params);
 
 			assert(knex.where.calledOnce);
 
@@ -338,7 +367,9 @@ describe('Build Filters', () => {
 
 			model = makeModel({ fields });
 
-			QueryBuilderFilters.buildFilters(knex, model, params);
+			makeQueryBuilder(model);
+
+			queryBuilderFilters.buildFilters(knex, model, params);
 
 			assert(knex.where.calledOnce);
 
@@ -355,7 +386,9 @@ describe('Build Filters', () => {
 
 			model = makeModel({ fields });
 
-			QueryBuilderFilters.buildFilters(knex, model, params);
+			makeQueryBuilder(model);
+
+			queryBuilderFilters.buildFilters(knex, model, params);
 
 			assert(knex.where.calledOnce);
 
@@ -372,7 +405,9 @@ describe('Build Filters', () => {
 
 			model = makeModel({ fields });
 
-			QueryBuilderFilters.buildFilters(knex, model, params);
+			makeQueryBuilder(model);
+
+			queryBuilderFilters.buildFilters(knex, model, params);
 
 			assert(knex.where.calledOnce);
 
@@ -389,7 +424,9 @@ describe('Build Filters', () => {
 
 			model = makeModel({ fields });
 
-			QueryBuilderFilters.buildFilters(knex, model, params);
+			makeQueryBuilder(model);
+
+			queryBuilderFilters.buildFilters(knex, model, params);
 
 			assert(knex.where.calledOnce);
 
@@ -406,7 +443,9 @@ describe('Build Filters', () => {
 
 			model = makeModel({ fields });
 
-			QueryBuilderFilters.buildFilters(knex, model, params);
+			makeQueryBuilder(model);
+
+			queryBuilderFilters.buildFilters(knex, model, params);
 
 			assert(knex.where.calledOnce);
 
@@ -423,7 +462,9 @@ describe('Build Filters', () => {
 
 			model = makeModel({ fields });
 
-			QueryBuilderFilters.buildFilters(knex, model, params);
+			makeQueryBuilder(model);
+
+			queryBuilderFilters.buildFilters(knex, model, params);
 
 			assert(knex.where.calledOnce);
 
@@ -440,7 +481,9 @@ describe('Build Filters', () => {
 
 			model = makeModel({ fields });
 
-			QueryBuilderFilters.buildFilters(knex, model, params);
+			makeQueryBuilder(model);
+
+			queryBuilderFilters.buildFilters(knex, model, params);
 
 			assert(knex.where.calledOnce);
 
@@ -457,7 +500,9 @@ describe('Build Filters', () => {
 
 			model = makeModel({ fields });
 
-			QueryBuilderFilters.buildFilters(knex, model, params);
+			makeQueryBuilder(model);
+
+			queryBuilderFilters.buildFilters(knex, model, params);
 
 			assert(knex.where.calledOnce);
 
@@ -474,7 +519,9 @@ describe('Build Filters', () => {
 
 			model = makeModel({ fields });
 
-			QueryBuilderFilters.buildFilters(knex, model, params);
+			makeQueryBuilder(model);
+
+			queryBuilderFilters.buildFilters(knex, model, params);
 
 			assert(knex.where.calledOnce);
 
@@ -501,7 +548,9 @@ describe('Build Filters', () => {
 				filters: { isActive: 0, error: 0 }
 			};
 
-			QueryBuilderFilters.buildFilters(knex, model, params);
+			makeQueryBuilder(model);
+
+			queryBuilderFilters.buildFilters(knex, model, params);
 
 			assert(knex.where.calledOnce);
 
@@ -530,7 +579,9 @@ describe('Build Filters', () => {
 				filters: { isActive: '0', error: '0' }
 			};
 
-			QueryBuilderFilters.buildFilters(knex, model, params);
+			makeQueryBuilder(model);
+
+			queryBuilderFilters.buildFilters(knex, model, params);
 
 			assert(knex.where.calledOnce);
 
@@ -559,7 +610,9 @@ describe('Build Filters', () => {
 				filters: { isActive: 'false', error: false }
 			};
 
-			QueryBuilderFilters.buildFilters(knex, model, params);
+			makeQueryBuilder(model);
+
+			queryBuilderFilters.buildFilters(knex, model, params);
 
 			assert(knex.where.calledOnce);
 
@@ -588,7 +641,9 @@ describe('Build Filters', () => {
 				filters: { isActive: 5, error: true }
 			};
 
-			QueryBuilderFilters.buildFilters(knex, model, params);
+			makeQueryBuilder(model);
+
+			queryBuilderFilters.buildFilters(knex, model, params);
 
 			assert(knex.where.calledOnce);
 

--- a/tests/query-builder-group-test.js
+++ b/tests/query-builder-group-test.js
@@ -50,6 +50,15 @@ const makeModel = ({
 	return new FakeModel();
 };
 
+let queryBuilderGroup;
+
+const makeQueryBuilder = model => {
+	if(!model)
+		queryBuilderGroup = new QueryBuilderGroup(makeModel({}));
+	else
+		queryBuilderGroup = new QueryBuilderGroup(model);
+};
+
 describe('Build Group', () => {
 	let knex;
 	let model;
@@ -58,6 +67,7 @@ describe('Build Group', () => {
 	context('when no Knex function or Model is passed', () => {
 
 		beforeEach(() => {
+			makeQueryBuilder();
 			knex = makeKnex();
 		});
 
@@ -67,13 +77,13 @@ describe('Build Group', () => {
 
 		it('should return QueryBuilderError if no params is passed', () => {
 
-			assert.throws(() => QueryBuilderGroup.buildGroup(), { code: QueryBuilderError.codes.INVALID_KNEX });
+			assert.throws(() => queryBuilderGroup.buildGroup(), { code: QueryBuilderError.codes.INVALID_KNEX });
 
 		});
 
 		it('should return QueryBuilderError if no Model is passed', () => {
 
-			assert.throws(() => QueryBuilderGroup.buildGroup(knex), { code: QueryBuilderError.codes.INVALID_MODEL });
+			assert.throws(() => queryBuilderGroup.buildGroup(knex), { code: QueryBuilderError.codes.INVALID_MODEL });
 
 		});
 
@@ -82,6 +92,7 @@ describe('Build Group', () => {
 	context('when params are missing or wrong', () => {
 
 		beforeEach(() => {
+			makeQueryBuilder();
 			knex = makeKnex();
 		});
 
@@ -93,7 +104,7 @@ describe('Build Group', () => {
 			params = {};
 			model = makeModel({});
 
-			QueryBuilderGroup.buildGroup(knex, model, params);
+			queryBuilderGroup.buildGroup(knex, model, params);
 
 			assert.equal(knex.groupBy.called, false);
 		});
@@ -102,7 +113,7 @@ describe('Build Group', () => {
 			params = { group: { foo: 'bar' } };
 			model = makeModel({});
 
-			assert.throws(() => QueryBuilderGroup.buildGroup(knex, model, params), { code: QueryBuilderError.codes.INVALID_GROUPS });
+			assert.throws(() => queryBuilderGroup.buildGroup(knex, model, params), { code: QueryBuilderError.codes.INVALID_GROUPS });
 			assert.equal(knex.groupBy.called, false);
 		});
 
@@ -114,7 +125,9 @@ describe('Build Group', () => {
 				fields: { foo: true }
 			});
 
-			QueryBuilderGroup.buildGroup(knex, model, params);
+			makeQueryBuilder(model);
+
+			queryBuilderGroup.buildGroup(knex, model, params);
 
 			assert.equal(knex.groupBy.called, false);
 		});
@@ -127,7 +140,9 @@ describe('Build Group', () => {
 				fields: { foo: true }
 			});
 
-			assert.throws(() => QueryBuilderGroup.buildGroup(knex, model, params), { code: QueryBuilderError.codes.INVALID_GROUPS });
+			makeQueryBuilder(model);
+
+			assert.throws(() => queryBuilderGroup.buildGroup(knex, model, params), { code: QueryBuilderError.codes.INVALID_GROUPS });
 
 		});
 
@@ -139,7 +154,9 @@ describe('Build Group', () => {
 				fields: { foo: true }
 			});
 
-			assert.throws(() => QueryBuilderGroup.buildGroup(knex, model, params), { code: QueryBuilderError.codes.INVALID_FIELDS });
+			makeQueryBuilder(model);
+
+			assert.throws(() => queryBuilderGroup.buildGroup(knex, model, params), { code: QueryBuilderError.codes.INVALID_FIELDS });
 		});
 
 		it('Should throws Error if valid \'params.group\' passed but unknown field in an array', () => {
@@ -150,7 +167,9 @@ describe('Build Group', () => {
 				fields: { foo: true }
 			});
 
-			assert.throws(() => QueryBuilderGroup.buildGroup(knex, model, params), { code: QueryBuilderError.codes.INVALID_FIELDS });
+			makeQueryBuilder(model);
+
+			assert.throws(() => queryBuilderGroup.buildGroup(knex, model, params), { code: QueryBuilderError.codes.INVALID_FIELDS });
 		});
 
 		it('Should throws Error if \'params.group\' as an empty array', () => {
@@ -161,7 +180,9 @@ describe('Build Group', () => {
 				fields: { foo: true }
 			});
 
-			assert.throws(() => QueryBuilderGroup.buildGroup(knex, model, params), { code: QueryBuilderError.codes.INVALID_GROUPS });
+			makeQueryBuilder(model);
+
+			assert.throws(() => queryBuilderGroup.buildGroup(knex, model, params), { code: QueryBuilderError.codes.INVALID_GROUPS });
 		});
 
 	});
@@ -184,7 +205,9 @@ describe('Build Group', () => {
 				group: 'foo'
 			};
 
-			QueryBuilderGroup.buildGroup(knex, model, params);
+			makeQueryBuilder(model);
+
+			queryBuilderGroup.buildGroup(knex, model, params);
 
 			assert(knex.groupBy.calledOnce);
 			assert.deepEqual(knex.groupBy.args[0], ['t.foo']);
@@ -198,7 +221,9 @@ describe('Build Group', () => {
 				group: ['foo', 'foo', 'bar'] // arrayUnique for avoid repetition
 			};
 
-			QueryBuilderGroup.buildGroup(knex, model, params);
+			makeQueryBuilder(model);
+
+			queryBuilderGroup.buildGroup(knex, model, params);
 
 			assert(knex.groupBy.calledTwice);
 			assert.deepEqual(knex.groupBy.args[0], ['t.foo']);
@@ -217,7 +242,9 @@ describe('Build Group', () => {
 				group: 'isActive'
 			};
 
-			QueryBuilderGroup.buildGroup(knex, model, params);
+			makeQueryBuilder(model);
+
+			queryBuilderGroup.buildGroup(knex, model, params);
 
 			assert(knex.groupByRaw.calledOnce);
 			assert.deepEqual(knex.groupByRaw.args[0], ['(t.status & 1)']);

--- a/tests/query-builder-joins-test.js
+++ b/tests/query-builder-joins-test.js
@@ -50,6 +50,15 @@ const makeModel = ({
 	return new FakeModel();
 };
 
+let queryBuilderJoins;
+
+const makeQueryBuilder = model => {
+	if(!model)
+		queryBuilderJoins = new QueryBuilderJoins(makeModel({}));
+	else
+		queryBuilderJoins = new QueryBuilderJoins(model);
+};
+
 describe('Build Joins', () => {
 	let knex;
 	let model;
@@ -58,6 +67,7 @@ describe('Build Joins', () => {
 	context('when no Knex function or Model is passed', () => {
 
 		beforeEach(() => {
+			makeQueryBuilder();
 			knex = makeKnex();
 		});
 
@@ -67,13 +77,13 @@ describe('Build Joins', () => {
 
 		it('should return QueryBuilderError if no params is passed', () => {
 
-			assert.throws(() => QueryBuilderJoins.buildJoins(), { code: QueryBuilderError.codes.INVALID_KNEX });
+			assert.throws(() => queryBuilderJoins.buildJoins(), { code: QueryBuilderError.codes.INVALID_KNEX });
 
 		});
 
 		it('should return QueryBuilderError if no Model is passed', () => {
 
-			assert.throws(() => QueryBuilderJoins.buildJoins(knex), { code: QueryBuilderError.codes.INVALID_MODEL });
+			assert.throws(() => queryBuilderJoins.buildJoins(knex), { code: QueryBuilderError.codes.INVALID_MODEL });
 
 		});
 
@@ -84,6 +94,7 @@ describe('Build Joins', () => {
 		const joinKnexMethods = ['join', 'innerJoin', 'leftJoin', 'leftOuter', 'rightJoin', 'rightOuterJoin', 'fullOuterJoin', 'crossJoin'];
 
 		beforeEach(() => {
+			makeQueryBuilder();
 			knex = makeKnex();
 		});
 
@@ -95,7 +106,7 @@ describe('Build Joins', () => {
 			model = makeModel({});
 			params = {};
 
-			QueryBuilderJoins.buildJoins(knex, model, params);
+			queryBuilderJoins.buildJoins(knex, model, params);
 
 			joinKnexMethods.forEach(method => {
 				assert.equal(knex[method].called, false);
@@ -109,7 +120,9 @@ describe('Build Joins', () => {
 				joins: ['foo']
 			};
 
-			assert.throws(() => QueryBuilderJoins.buildJoins(knex, model, params), { code: QueryBuilderError.codes.INVALID_FIELDS });
+			makeQueryBuilder(model);
+
+			assert.throws(() => queryBuilderJoins.buildJoins(knex, model, params), { code: QueryBuilderError.codes.INVALID_FIELDS });
 
 			joinKnexMethods.forEach(method => {
 				assert.equal(knex[method].called, false);
@@ -121,7 +134,7 @@ describe('Build Joins', () => {
 				joins: ['foo']
 			};
 
-			assert.throws(() => QueryBuilderJoins.buildJoins(knex, model, params), { code: QueryBuilderError.codes.INVALID_JOINS });
+			assert.throws(() => queryBuilderJoins.buildJoins(knex, model, params), { code: QueryBuilderError.codes.INVALID_JOINS });
 
 			joinKnexMethods.forEach(method => {
 				assert.equal(knex[method].called, false);
@@ -136,7 +149,9 @@ describe('Build Joins', () => {
 				joins: 'foo'
 			};
 
-			assert.throws(() => QueryBuilderJoins.buildJoins(knex, model, params), { code: QueryBuilderError.codes.INVALID_JOINS });
+			makeQueryBuilder(model);
+
+			assert.throws(() => queryBuilderJoins.buildJoins(knex, model, params), { code: QueryBuilderError.codes.INVALID_JOINS });
 		});
 		it('Should throws Error if \'params.joins\' passed but join definition missing', () => {
 			model = makeModel({
@@ -146,7 +161,9 @@ describe('Build Joins', () => {
 				joins: ['foo']
 			};
 
-			assert.throws(() => QueryBuilderJoins.buildJoins(knex, model, params), { code: QueryBuilderError.codes.INVALID_JOINS });
+			makeQueryBuilder(model);
+
+			assert.throws(() => queryBuilderJoins.buildJoins(knex, model, params), { code: QueryBuilderError.codes.INVALID_JOINS });
 		});
 		it('Should throws Error if \'params.joins\' and join definition join key does not match', () => {
 			model = makeModel({
@@ -157,7 +174,9 @@ describe('Build Joins', () => {
 				joins: ['foo']
 			};
 
-			assert.throws(() => QueryBuilderJoins.buildJoins(knex, model, params), { code: QueryBuilderError.codes.INVALID_JOINS });
+			makeQueryBuilder(model);
+
+			assert.throws(() => queryBuilderJoins.buildJoins(knex, model, params), { code: QueryBuilderError.codes.INVALID_JOINS });
 		});
 		it('Should throws Error if join definition is invalid', () => {
 			model = makeModel({
@@ -173,7 +192,9 @@ describe('Build Joins', () => {
 				joins: ['joinA', 'joinA', 'joinC', 'joinD']
 			};
 
-			assert.throws(() => QueryBuilderJoins.buildJoins(knex, model, params), { code: QueryBuilderError.codes.INVALID_JOINS });
+			makeQueryBuilder(model);
+
+			assert.throws(() => queryBuilderJoins.buildJoins(knex, model, params), { code: QueryBuilderError.codes.INVALID_JOINS });
 		});
 		it('Should throws Error if \'alias\' is missing in join definition', () => {
 			model = makeModel({
@@ -184,7 +205,9 @@ describe('Build Joins', () => {
 				joins: ['joinA']
 			};
 
-			assert.throws(() => QueryBuilderJoins.buildJoins(knex, model, params), { code: QueryBuilderError.codes.INVALID_JOINS });
+			makeQueryBuilder(model);
+
+			assert.throws(() => queryBuilderJoins.buildJoins(knex, model, params), { code: QueryBuilderError.codes.INVALID_JOINS });
 		});
 		it('Should throws Error if \'method\' is missing in join definition', () => {
 			model = makeModel({
@@ -195,7 +218,9 @@ describe('Build Joins', () => {
 				joins: ['joinA']
 			};
 
-			assert.throws(() => QueryBuilderJoins.buildJoins(knex, model, params), { code: QueryBuilderError.codes.INVALID_JOINS });
+			makeQueryBuilder(model);
+
+			assert.throws(() => queryBuilderJoins.buildJoins(knex, model, params), { code: QueryBuilderError.codes.INVALID_JOINS });
 		});
 		it('Should throws Error if \'method\' is invalid in join definition', () => {
 			model = makeModel({
@@ -206,7 +231,9 @@ describe('Build Joins', () => {
 				joins: ['joinA']
 			};
 
-			assert.throws(() => QueryBuilderJoins.buildJoins(knex, model, params), { code: QueryBuilderError.codes.INVALID_JOINS });
+			makeQueryBuilder(model);
+
+			assert.throws(() => queryBuilderJoins.buildJoins(knex, model, params), { code: QueryBuilderError.codes.INVALID_JOINS });
 		});
 		it('Should throws Error if \'on\' and \'orOn\' is missing in join definition', () => {
 			model = makeModel({
@@ -217,7 +244,9 @@ describe('Build Joins', () => {
 				joins: ['joinA']
 			};
 
-			assert.throws(() => QueryBuilderJoins.buildJoins(knex, model, params), { code: QueryBuilderError.codes.INVALID_JOINS });
+			makeQueryBuilder(model);
+
+			assert.throws(() => queryBuilderJoins.buildJoins(knex, model, params), { code: QueryBuilderError.codes.INVALID_JOINS });
 		});
 		it('Should throws Error if \'on\' and \'orOn\' are invalid in join definition', () => {
 			const invalidOns = [
@@ -247,14 +276,18 @@ describe('Build Joins', () => {
 					joins: ['tableA']
 				};
 
-				assert.throws(() => QueryBuilderJoins.buildJoins(knex, model, params));
+				makeQueryBuilder(model);
+
+				assert.throws(() => queryBuilderJoins.buildJoins(knex, model, params));
 
 				model = makeModel({
 					fields: { foo: true, bar: true },
 					joins: { tableA: { alias: 'j', orOn: invalidOn } }
 				});
 
-				assert.throws(() => QueryBuilderJoins.buildJoins(knex, model, params));
+				makeQueryBuilder(model);
+
+				assert.throws(() => queryBuilderJoins.buildJoins(knex, model, params));
 			});
 		});
 	});
@@ -267,7 +300,9 @@ describe('Build Joins', () => {
 
 			params = param;
 
-			QueryBuilderJoins.buildJoins(knex, model, params);
+			makeQueryBuilder(model);
+
+			queryBuilderJoins.buildJoins(knex, model, params);
 
 			assert(knex[joinMethod].calledOnce);
 			assert.equal(knex[joinMethod].args[0][0], joinTable);

--- a/tests/query-builder-order-test.js
+++ b/tests/query-builder-order-test.js
@@ -49,6 +49,14 @@ const makeModel = ({
 	return new FakeModel();
 };
 
+let queryBuilderOrder;
+
+const makeQueryBuilder = model => {
+	if(!model)
+		queryBuilderOrder = new QueryBuilderOrder(makeModel({}));
+	else
+		queryBuilderOrder = new QueryBuilderOrder(model);
+};
 
 describe('Build Order', () => {
 	let knex;
@@ -58,6 +66,7 @@ describe('Build Order', () => {
 	context('when no Knex function or Model is passed', () => {
 
 		beforeEach(() => {
+			makeQueryBuilder();
 			knex = makeKnex();
 		});
 
@@ -67,13 +76,13 @@ describe('Build Order', () => {
 
 		it('should return QueryBuilderError if no params is passed', () => {
 
-			assert.throws(() => QueryBuilderOrder.buildOrder(), { code: QueryBuilderError.codes.INVALID_KNEX });
+			assert.throws(() => queryBuilderOrder.buildOrder(), { code: QueryBuilderError.codes.INVALID_KNEX });
 
 		});
 
 		it('should return QueryBuilderError if no Model is passed', () => {
 
-			assert.throws(() => QueryBuilderOrder.buildOrder(knex), { code: QueryBuilderError.codes.INVALID_MODEL });
+			assert.throws(() => queryBuilderOrder.buildOrder(knex), { code: QueryBuilderError.codes.INVALID_MODEL });
 
 		});
 
@@ -82,6 +91,7 @@ describe('Build Order', () => {
 	context('when params are missing or wrong', () => {
 
 		beforeEach(() => {
+			makeQueryBuilder();
 			knex = makeKnex();
 		});
 
@@ -94,7 +104,7 @@ describe('Build Order', () => {
 			model = makeModel({});
 			params = {};
 
-			QueryBuilderOrder.buildOrder(knex, model, params);
+			queryBuilderOrder.buildOrder(knex, model, params);
 
 			assert.equal(knex.orderBy.called, false);
 
@@ -107,7 +117,7 @@ describe('Build Order', () => {
 				order: 'id'
 			};
 
-			assert.throws(() => QueryBuilderOrder.buildOrder(knex, model, params), { code: QueryBuilderError.codes.INVALID_FIELDS });
+			assert.throws(() => queryBuilderOrder.buildOrder(knex, model, params), { code: QueryBuilderError.codes.INVALID_FIELDS });
 			assert.equal(knex.orderBy.called, false);
 
 		});
@@ -121,7 +131,9 @@ describe('Build Order', () => {
 				order: ['id']
 			};
 
-			assert.throws(() => QueryBuilderOrder.buildOrder(knex, model, params), { code: QueryBuilderError.codes.INVALID_ORDERS });
+			makeQueryBuilder(model);
+
+			assert.throws(() => queryBuilderOrder.buildOrder(knex, model, params), { code: QueryBuilderError.codes.INVALID_ORDERS });
 		});
 
 		it('Should trhows Error if invalid direction in order is passed', () => {
@@ -133,7 +145,9 @@ describe('Build Order', () => {
 				order: { id: 'foo' }
 			};
 
-			assert.throws(() => QueryBuilderOrder.buildOrder(knex, model, params), { code: QueryBuilderError.codes.INVALID_ORDERS });
+			makeQueryBuilder(model);
+
+			assert.throws(() => queryBuilderOrder.buildOrder(knex, model, params), { code: QueryBuilderError.codes.INVALID_ORDERS });
 		});
 
 		it('Should trhows Error if field is not present in definition', () => {
@@ -145,7 +159,9 @@ describe('Build Order', () => {
 				order: 'bar'
 			};
 
-			assert.throws(() => QueryBuilderOrder.buildOrder(knex, model, params), { code: QueryBuilderError.codes.INVALID_FIELDS });
+			makeQueryBuilder(model);
+
+			assert.throws(() => queryBuilderOrder.buildOrder(knex, model, params), { code: QueryBuilderError.codes.INVALID_FIELDS });
 		});
 	});
 
@@ -168,7 +184,9 @@ describe('Build Order', () => {
 				order: 'name'
 			};
 
-			QueryBuilderOrder.buildOrder(knex, model, params);
+			makeQueryBuilder(model);
+
+			queryBuilderOrder.buildOrder(knex, model, params);
 
 			assert.equal(knex.orderBy.called, true);
 			assert.equal(knex.orderBy.calledOnce, true);
@@ -185,7 +203,9 @@ describe('Build Order', () => {
 				order: { code: 'desc' }
 			};
 
-			QueryBuilderOrder.buildOrder(knex, model, params);
+			makeQueryBuilder(model);
+
+			queryBuilderOrder.buildOrder(knex, model, params);
 
 			assert.equal(knex.orderBy.called, true);
 			assert.equal(knex.orderBy.calledOnce, true);
@@ -201,7 +221,9 @@ describe('Build Order', () => {
 				order: { name: 'desc', id: 'asc' }
 			};
 
-			QueryBuilderOrder.buildOrder(knex, model, params);
+			makeQueryBuilder(model);
+
+			queryBuilderOrder.buildOrder(knex, model, params);
 
 			assert.equal(knex.orderBy.called, true);
 			assert.equal(knex.orderBy.calledTwice, true);
@@ -222,7 +244,9 @@ describe('Build Order', () => {
 				order: 'isActive'
 			};
 
-			QueryBuilderOrder.buildOrder(knex, model, params);
+			makeQueryBuilder(model);
+
+			queryBuilderOrder.buildOrder(knex, model, params);
 
 			assert.equal(knex.orderByRaw.called, true);
 			assert.equal(knex.orderByRaw.calledOnce, true);
@@ -230,7 +254,6 @@ describe('Build Order', () => {
 			assert.deepEqual(knex.orderByRaw.args[0], ['(t.status & 1) asc']);
 
 		});
-
 
 	});
 


### PR DESCRIPTION
**JCN-172-QUERY-BUILDER-ESTATICO**
JCN-172 Package QueryBuilder estático

**LINK AL TICKET**
https://fizzmod.atlassian.net/browse/JCN-172

**DESCRIPCIÓN DEL REQUERIMIENTO**
En el package QueryBuilder se están usando "clases helpers" para manejar distintos componentes de las queries.
Las mismas se usan como estáticas, usando static, pero guardan datos de cada ejecución en this.
Esto produce que si 2 distintos orígenes usan la misma clase a la vez, se mezclarían los datos.
Se deben arreglar las clases usando siempre las clases como objetos instanciados (con this)
Las clases con estos errores son las siguientes:

- QueryBuilderSelect
- QueryBuilderFilters
- QueryBuilderGroup
- QueryBuilderJoins
- QueryBuilderOrder

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se convirtieron los helpers en instanciables, se actualizaron los tests individuales de cada helper y tambien la clase principal para el nuevo comportamiento, el funcionamiento y uso del `query-builder` no se vio afectado debido a que solo fueron cambios internos.